### PR TITLE
Feature/murcli

### DIFF
--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -211,7 +211,7 @@ module MrMurano
       type = type.to_sym
       raise "Unknown type(#{type})" unless type == :all or ALLOWED_TYPES.include? type
       # Cache the result since sometimes both products() and applications() are called.
-      if @bizSolns.nil? or invalidate
+      if !instance_variable_defined?("@bizSolns") or invalidate
         got = get('business/' + $cfg['business.id'] + '/solution/')
         @bizSolns = got
       end

--- a/lib/MrMurano/Webservice.rb
+++ b/lib/MrMurano/Webservice.rb
@@ -12,6 +12,8 @@ module MrMurano
       def initialize
         @pid = $cfg['application.id']
         raise MrMurano::ConfigError.new("No application id!") if @pid.nil?
+        # FIXME/2017-06-05/MRMUR-XXXX: Update to new endpoint.
+        #@uriparts = [:service, @pid, :webservice]
         @uriparts = [:solution, @pid]
         @itemkey = :id
         @locationbase = $cfg['location.base']

--- a/lib/MrMurano/http.rb
+++ b/lib/MrMurano/http.rb
@@ -3,6 +3,9 @@ require 'uri'
 require 'net/http'
 require 'json'
 require('certified') if Gem.win_platform?
+# 2017-06-07: [lb] getting "execution expired (Net::OpenTimeout)" on http.start.
+# Suggestions online say to load the pure-Ruby DNS implementation, resolv.rb.
+require 'resolv-replace'
 
 module MrMurano
   module Http

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
 module MrMurano
-  VERSION = '3.0.0.beta.1'.freeze
+  VERSION = '3.0.0.beta.2'.freeze
 end
 

--- a/spec/cmd_syncup_spec.rb
+++ b/spec/cmd_syncup_spec.rb
@@ -43,6 +43,9 @@ RSpec.describe 'murano syncup', :cmd, :needs_password do
       FileUtils.move('assets','files')
       FileUtils.mkpath('specs')
       FileUtils.copy(File.join(@testdir, 'spec/fixtures/product_spec_files/lightbulb.yaml'), 'specs/resources.yaml')
+      dev_symlink = File.join(Dir.tmpdir(), "murcli-test")
+      FileUtils.rm(dev_symlink)
+      FileUtils.ln_s(Dir.pwd, dev_symlink)
     end
 
     it "syncup" do

--- a/spec/cmd_syncup_spec.rb
+++ b/spec/cmd_syncup_spec.rb
@@ -43,9 +43,12 @@ RSpec.describe 'murano syncup', :cmd, :needs_password do
       FileUtils.move('assets','files')
       FileUtils.mkpath('specs')
       FileUtils.copy(File.join(@testdir, 'spec/fixtures/product_spec_files/lightbulb.yaml'), 'specs/resources.yaml')
-      dev_symlink = File.join(Dir.tmpdir(), "murcli-test")
-      FileUtils.rm(dev_symlink)
-      FileUtils.ln_s(Dir.pwd, dev_symlink)
+      @dev_symlink = File.join(Dir.tmpdir(), "murcli-test")
+      FileUtils.rm(@dev_symlink, :force => true)
+      FileUtils.ln_s(Dir.pwd, @dev_symlink)
+    end
+    after(:example) do
+      FileUtils.rm(@dev_symlink, :force => true)
     end
 
     it "syncup" do


### PR DESCRIPTION
1. Pagination support. I added this to Solution::get(). The code is meant to be generic; e.g., I didn't figure out which subclasses might do pagination, but instead decide on the fly in the get() routine if the request appears paginated. I think this solution will work fine...

2. Ruby http.rb raising "execution expired (Net::OpenTimeout)". I'm not sure why I'm seeing this today, but haven't seen it in the past, as it happens seemingly randomly on different tests. I Googled, and the suggestions I found all said to add "require 'resolv-replace'" and that would solve it -- that is, use the pure-Ruby DNS implementation in resolv.rb and do not rely on the local system DNS implementation. I'm not super confident in this change, as I'm not sure if it'll change any other behavior. But it seems to work, and without it, my tests don't all pass...