### PR TITLE
Feature/murcli

### DIFF
--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -108,11 +108,6 @@ module MrMurano
         showHttpError(request, response)
         error 'Check to see if username and password are correct.'
         @token = nil
-        # 2017-07-13: This doesn't seem like something we can ignore.
-# FIXME/2017-07-13: Trying to determine why Travis tests are failing...
-#        exit 99
-# FIXME/2017-07-13: Travis doesn't like the exit 99...
-        exit 1
       end
     end
 

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -108,6 +108,8 @@ module MrMurano
         showHttpError(request, response)
         error 'Check to see if username and password are correct.'
         @token = nil
+        # 2017-07-13: This doesn't seem like something we can ignore.
+        exit 99
       end
     end
 

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -111,6 +111,8 @@ module MrMurano
         # 2017-07-13: This doesn't seem like something we can ignore.
 # FIXME/2017-07-13: Trying to determine why Travis tests are failing...
 #        exit 99
+# FIXME/2017-07-13: Travis doesn't like the exit 99...
+        exit 1
       end
     end
 

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.05 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -49,20 +49,24 @@ module MrMurano
     def login_info
       warned_once = false
       if user.empty?
+        MrMurano::Verbose.whirly_pause
         error('No Murano user account found. Please login')
         warned_once = true
         username = ask('User name: ')
         $cfg.set('user.name', username, :user)
+        MrMurano::Verbose.whirly_unpause
       end
       pwd_path = $cfg.file_at('passwords', :user)
       pwd_file = MrMurano::Passwords.new(pwd_path)
       pwd_file.load
       user_pass = pwd_file.get(host, user)
       if user_pass.nil?
+        MrMurano::Verbose.whirly_pause
         error("No Murano password found for #{user}") unless warned_once
         user_pass = ask('Password: ') { |q| q.echo = '*' }
         pwd_file.set(host, user, user_pass)
         pwd_file.save
+        MrMurano::Verbose.whirly_unpause
       end
       creds = {
         email: user,

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -109,7 +109,8 @@ module MrMurano
         error 'Check to see if username and password are correct.'
         @token = nil
         # 2017-07-13: This doesn't seem like something we can ignore.
-        exit 99
+# FIXME/2017-07-13: Trying to determine why Travis tests are failing...
+#        exit 99
       end
     end
 

--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -190,7 +190,7 @@ module MrMurano
         :defaults,
       )
       set('eventhandler.ignoring', '*_test.lua *_spec.lua .*', :defaults)
-      set('eventhandler.skiplist', 'websocket webservice device.service_call interface', :defaults)
+      set('eventhandler.skiplist', 'websocket webservice device.service_call interface device2.event', :defaults)
 
       set('modules.searchFor', '*.lua */*.lua', :defaults)
       set('modules.ignoring', '*_test.lua *_spec.lua .*', :defaults)

--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.05 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -190,7 +190,7 @@ module MrMurano
         :defaults,
       )
       set('eventhandler.ignoring', '*_test.lua *_spec.lua .*', :defaults)
-      set('eventhandler.skiplist', 'websocket webservice device.service_call', :defaults)
+      set('eventhandler.skiplist', 'websocket webservice device.service_call interface', :defaults)
 
       set('modules.searchFor', '*.lua */*.lua', :defaults)
       set('modules.ignoring', '*_test.lua *_spec.lua .*', :defaults)

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.03 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -275,17 +275,17 @@ module MrMurano
       # eventhandler.skiplist is a list of whitespace separated dot-paired values.
       # fe: service.event service service service.event
       skiplist = ($cfg['eventhandler.skiplist'] || '').split
-      items = ret[:items].reject do |i|
-        keep = (
-          i.key?(:service) &&
-          i.key?(:event) && (
-            skiplist.include?(i[:service]) ||
-            skiplist.include?("#{i[:service]}.#{i[:event]}")
+      items = ret[:items].reject do |item|
+        toss = (
+          item.key?(:service) &&
+          item.key?(:event) && (
+            skiplist.include?(item[:service]) ||
+            skiplist.include?("#{item[:service]}.#{item[:event]}")
           )
         )
-        keep
+        toss
       end
-      items.map { |i| EventHandlerItem.new(i) }
+      items.map { |item| EventHandlerItem.new(item) }
     end
 
     def fetch(name)

--- a/lib/MrMurano/commands/link.rb
+++ b/lib/MrMurano/commands/link.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.05 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -47,7 +47,7 @@ List the solutions that are linked.
 
     appl = solution_find_or_create(biz: biz, type: :application)
 
-    MrMurano::Verbose.whirly_msg 'Fetching application services...'
+    MrMurano::Verbose.whirly_msg('Fetching application services...')
     sercfg = MrMurano::ServiceConfig.new(appl.sid)
     #scfgs = sercfg.list('?select=service,id,solution_id,script_key,alias')
     scfgs = sercfg.list

--- a/lib/MrMurano/commands/show.rb
+++ b/lib/MrMurano/commands/show.rb
@@ -1,3 +1,9 @@
+# Last Modified: 2017.07.13 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
 
 command 'show' do |c|
   c.syntax = %(murano show)
@@ -7,70 +13,69 @@ Show readable information about the current configuration.
   ).strip
   c.project_not_required = true
 
-  c.action do |args, options|
-
-    if args.include?('help') then
+  c.action do |args, _options|
+    if args.include?('help')
       ::Commander::UI.enable_paging
       say MrMurano::SubCmdGroupHelp.new(c).get_help
     else
       acc = MrMurano::Account.instance
+      biz = MrMurano::Business.new
 
-      selectedBusinessId = $cfg['business.id']
-      selectedBusiness = nil
-      acc.businesses.each do |row|
-        selectedBusiness = row if row[:bizid] == selectedBusinessId
+      selected_business_id = $cfg['business.id']
+      selected_business = nil
+      acc.businesses.each do |sol|
+        selected_business = sol if sol.bizid == selected_business_id
       end
 
-      selectedProductId = $cfg['product.id']
-      selectedProduct = nil
-      acc.products.each do |row|
-        selectedProduct = row if row[:apiId] == selectedProductId
+      MrMurano::Verbose.whirly_start('Fetching Applications...')
+      selected_application_id = $cfg['application.id']
+      selected_application = nil
+      biz.applications.each do |sol|
+        selected_application = sol if sol.apiId == selected_application_id
       end
+      MrMurano::Verbose.whirly_stop
 
-      selectedApplicationId = $cfg['application.id']
-      selectedApplication = nil
-      acc.applications.each do |row|
-        selectedApplication = row if row[:apiId] == selectedApplicationId
+      MrMurano::Verbose.whirly_start('Fetching Products...')
+      selected_product_id = $cfg['product.id']
+      selected_product = nil
+      biz.products.each do |sol|
+        selected_product = sol if sol.apiId == selected_product_id
       end
+      MrMurano::Verbose.whirly_stop
 
-      if $cfg['user.name'] then
+      if $cfg['user.name']
         puts %(user: #{$cfg['user.name']})
       else
         puts 'no user selected'
       end
 
-      if selectedBusiness then
-        puts %(business: #{selectedBusiness[:name]})
+      if selected_business
+        puts %(business: #{selected_business.name})
       else
         puts 'no business selected'
-      end
-
-      # E.g., {:bizid=>"AAAAAAAAAAAAAAAA", :type=>"product",
-      #   :apiId=>"BBBBBBBBBBBBBBBBB", :sid=>"BBBBBBBBBBBBBBBBB",
-      #   :domain=>"BBBBBBBBBBBBBBBBB.m2.exosite.io", :name=>"AAAAAAAAAAAAAAAA"}
-      if selectedProduct then
-        puts %(product: #{selectedProduct[:name]})
-      else
-        if selectedProductId then
-          puts 'selected product not in business'
-        else
-          puts 'no product selected'
-        end
       end
 
       # E.g., {:bizid=>"AAAAAAAAAAAAAAAA", :type=>"application",
       #   :apiId=>"CCCCCCCCCCCCCCCCC", :sid=>"CCCCCCCCCCCCCCCCC",
       #   :domain=>"AAAAAAAAAAAAAAAA.apps.exosite.io", :name=>"AAAAAAAAAAAAAAAA"}
-      if selectedApplication then
-        puts %(application: https://#{selectedApplication[:domain]})
+      if selected_application
+        puts %(application: https://#{selected_application.domain})
+      elsif selected_application_id
+        puts 'selected application not in business'
       else
-        if selectedApplicationId then
-          puts 'selected application not in business'
-        else
-          puts 'no application selected'
-        end
+        puts 'no application selected'
       end
 
+      # E.g., {:bizid=>"AAAAAAAAAAAAAAAA", :type=>"product",
+      #   :apiId=>"BBBBBBBBBBBBBBBBB", :sid=>"BBBBBBBBBBBBBBBBB",
+      #   :domain=>"BBBBBBBBBBBBBBBBB.m2.exosite.io", :name=>"AAAAAAAAAAAAAAAA"}
+      if selected_product
+        puts %(product: #{selected_product.name})
+      elsif selected_product_id
+        puts 'selected product not in business'
+      else
+        puts 'no product selected'
+      end
     end
   end
 end
@@ -83,11 +88,9 @@ Show readable information about the current configuration.
   ).strip
   c.project_not_required = true
 
-  c.action do |args, options|
+  c.action do |_args, _options|
     puts %(base: #{$cfg['location.base']})
     $cfg['location'].each { |key, value| puts %(#{key}: #{$cfg['location.base']}/#{value}) }
   end
 end
-
-#  vim: set ai et sw=2 ts=2 :
 

--- a/lib/MrMurano/commands/solution.rb
+++ b/lib/MrMurano/commands/solution.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.05 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -306,8 +306,11 @@ List solution in the current business.
       headers = %i[apiId domain]
       solz = solz.map { |row| [row.apiId, row.domain] }
     else
-      headers = (solz.first || {}).keys
-      solz = solz.map { |row| headers.map { |hdr| row[hdr] } }
+      headers = (solz.first.meta || {}).keys
+      if headers.include?(:apiId) and headers.include?(:sid)
+        headers.delete(:sid)
+      end
+      solz = solz.map { |row| headers.map { |hdr| row.meta[hdr] } }
     end
 
     if !solz.empty? || options.idonly

--- a/lib/MrMurano/progress.rb
+++ b/lib/MrMurano/progress.rb
@@ -15,8 +15,13 @@ module MrMurano
   class Progress
     include Singleton
 
-    #def initialize
-    #end
+    def initialize
+      @whirly_msg = ''
+      @whirly_time = nil
+      @whirly_users = 0
+      @whirly_cols = 0
+      @whirly_paused = false
+    end
 
     EXO_QUADRANTS = [
       '▚',
@@ -94,7 +99,7 @@ module MrMurano
 
     def whirly_pause
       return if defined?(@whirly_paused) && @whirly_paused
-      return if @whirly_users.zero?
+      return if !defined?(@whirly_users) || @whirly_users.zero?
       @whirly_paused = true
       whirly_clear
     end

--- a/lib/MrMurano/progress.rb
+++ b/lib/MrMurano/progress.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.05 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -37,12 +37,17 @@ module MrMurano
       # display a different message.
       @whirly_users = 0 unless defined?(@whirly_users)
       @whirly_users += 1
+      # The first Whirly message is the one we show.
       return if @whirly_users > 1
-
+      @whirly_msg = msg
       whirly_stop
+      whirly_show
+    end
+
+    def whirly_show
       Whirly.start(
         spinner: EXO_QUADRANTS,
-        status: msg,
+        status: @whirly_msg,
         append_newline: false,
       )
       @whirly_time = Time.now
@@ -57,8 +62,11 @@ module MrMurano
         @whirly_users -= 1
       end
       return unless @whirly_users.zero?
-
       whirly_linger
+      whirly_clear
+    end
+
+    def whirly_clear
       Whirly.stop
       # The progress indicator is always overwritten.
       return unless @whirly_cols
@@ -76,11 +84,25 @@ module MrMurano
     def whirly_msg(msg)
       return if $cfg['tool.no-progress']
       if defined?(@whirly_time)
+        @whirly_msg = msg
         #self.whirly_linger
-        Whirly.configure(status: msg)
+        Whirly.configure(status: @whirly_msg)
       else
         whirly_start msg
       end
+    end
+
+    def whirly_pause
+      return if defined?(@whirly_paused) && @whirly_paused
+      return if @whirly_users.zero?
+      @whirly_paused = true
+      whirly_clear
+    end
+
+    def whirly_unpause
+      return if !defined?(@whirly_paused) || !@whirly_paused
+      @whirly_paused = false
+      whirly_show
     end
   end
 end

--- a/lib/MrMurano/progress.rb
+++ b/lib/MrMurano/progress.rb
@@ -40,7 +40,6 @@ module MrMurano
       # printed. This way, methods can define a default message
       # to use, but then callers of those methods can choose to
       # display a different message.
-      @whirly_users = 0 unless defined?(@whirly_users)
       @whirly_users += 1
       # The first Whirly message is the one we show.
       return if @whirly_users > 1
@@ -60,7 +59,7 @@ module MrMurano
     end
 
     def whirly_stop(force: false)
-      return if $cfg['tool.no-progress'] || !defined?(@whirly_time)
+      return if $cfg['tool.no-progress'] || @whirly_time.nil?
       if force
         @whirly_users = 0
       else
@@ -80,32 +79,32 @@ module MrMurano
     end
 
     def whirly_linger
-      return if $cfg['tool.no-progress'] || !defined?(@whirly_time)
+      return if $cfg['tool.no-progress'] || @whirly_time.nil?
       not_so_fast = 0.55 - (Time.now - @whirly_time)
-      remove_instance_variable(:@whirly_time)
+      @whirly_time = nil
       sleep(not_so_fast) if not_so_fast > 0
     end
 
     def whirly_msg(msg)
       return if $cfg['tool.no-progress']
-      if defined?(@whirly_time)
+      if @whirly_time.nil?
+        whirly_start msg
+      else
         @whirly_msg = msg
         #self.whirly_linger
         Whirly.configure(status: @whirly_msg)
-      else
-        whirly_start msg
       end
     end
 
     def whirly_pause
-      return if defined?(@whirly_paused) && @whirly_paused
-      return if !defined?(@whirly_users) || @whirly_users.zero?
+      return if @whirly_paused
+      return if @whirly_users.zero?
       @whirly_paused = true
       whirly_clear
     end
 
     def whirly_unpause
-      return if !defined?(@whirly_paused) || !@whirly_paused
+      return if !@whirly_paused
       @whirly_paused = false
       whirly_show
     end

--- a/lib/MrMurano/verbosing.rb
+++ b/lib/MrMurano/verbosing.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.05 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -140,7 +140,9 @@ module MrMurano
       MrMurano::Verbose.pluralize?(word, count)
     end
 
-    # 2017-07-01: Whirly wrappers. Maybe delete someday.
+    # 2017-07-01: Whirly wrappers. Maybe delete someday
+    #   (after replacing all MrMurano::Verbose.whirly_*
+    #   with MrMurano::Progress.whirly_*).
 
     def whirly_start(msg)
       MrMurano::Progress.instance.whirly_start(msg)
@@ -158,6 +160,14 @@ module MrMurano
       MrMurano::Progress.instance.whirly_msg(msg)
     end
 
+    def whirly_pause
+      MrMurano::Progress.instance.whirly_pause
+    end
+
+    def whirly_unpause
+      MrMurano::Progress.instance.whirly_unpause
+    end
+
     def self.whirly_start(msg)
       MrMurano::Progress.instance.whirly_start(msg)
     end
@@ -172,6 +182,14 @@ module MrMurano
 
     def self.whirly_msg(msg)
       MrMurano::Progress.instance.whirly_msg(msg)
+    end
+
+    def self.whirly_pause
+      MrMurano::Progress.instance.whirly_pause
+    end
+
+    def self.whirly_unpause
+      MrMurano::Progress.instance.whirly_unpause
     end
   end
 end

--- a/spec/cmd_status_spec.rb
+++ b/spec/cmd_status_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.03 /coding: utf-8
+# Last Modified: 2017.07.13 /coding: utf-8
 # frozen_string_literal: probably not yet
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -85,27 +85,27 @@ RSpec.describe 'murano status', :cmd, :needs_password do
 
   def match_remote_boilerplate_v1_0_0_service(slice)
     expect(slice).to contain_exactly(
-      " - E  device2_event\n",
-      " - E  interface_addGatewayResource\n",
-      " - E  interface_addIdentity\n",
-      " - E  interface_clearContent\n",
-      " - E  interface_deleteContent\n",
-      " - E  interface_downloadContent\n",
-      " - E  interface_getGatewayResource\n",
-      " - E  interface_getGatewaySettings\n",
-      " - E  interface_getIdentity\n",
-      " - E  interface_getIdentityState\n",
-      " - E  interface_infoContent\n",
-      " - E  interface_listContent\n",
-      " - E  interface_listIdentities\n",
-      " - E  interface_makeIdentity\n",
-      " - E  interface_removeGatewayResource\n",
-      " - E  interface_removeIdentity\n",
-      " - E  interface_setIdentityState\n",
-      " - E  interface_updateGatewayResource\n",
-      " - E  interface_updateGatewaySettings\n",
-      " - E  interface_updateIdentity\n",
-      " - E  interface_uploadContent\n",
+      #" - E  device2_event\n",
+      #" - E  interface_addGatewayResource\n",
+      #" - E  interface_addIdentity\n",
+      #" - E  interface_clearContent\n",
+      #" - E  interface_deleteContent\n",
+      #" - E  interface_downloadContent\n",
+      #" - E  interface_getGatewayResource\n",
+      #" - E  interface_getGatewaySettings\n",
+      #" - E  interface_getIdentity\n",
+      #" - E  interface_getIdentityState\n",
+      #" - E  interface_infoContent\n",
+      #" - E  interface_listContent\n",
+      #" - E  interface_listIdentities\n",
+      #" - E  interface_makeIdentity\n",
+      #" - E  interface_removeGatewayResource\n",
+      #" - E  interface_removeIdentity\n",
+      #" - E  interface_setIdentityState\n",
+      #" - E  interface_updateGatewayResource\n",
+      #" - E  interface_updateGatewaySettings\n",
+      #" - E  interface_updateIdentity\n",
+      #" - E  interface_uploadContent\n",
       " - E  timer_timer\n",
       " - E  tsdb_exportJob\n",
       " - E  user_account\n",
@@ -238,10 +238,10 @@ RSpec.describe 'murano status', :cmd, :needs_password do
       expect(olines[0]).to eq("Only on local machine:\n")
       match_syncable_contents_except_singleRoute(olines[1..7])
       expect(olines[8]).to eq("Only on remote server:\n")
-      match_remote_boilerplate_v1_0_0_service(olines[9..32])
-      expect(olines[33]).to eq("Nothing that differs\n")
-      #expect(olines[32]).to eq("Items that differ:\n")
-      #expect(olines[33..33]).to contain_exactly(
+      match_remote_boilerplate_v1_0_0_service(olines[9..11])
+      expect(olines[12]).to eq("Nothing that differs\n")
+      #expect(olines[11]).to eq("Items that differ:\n")
+      #expect(olines[12..12]).to contain_exactly(
       #  a_string_matching(/ M E  .*services\/devdata\.lua/),
       #)
       expect(status.exitstatus).to eq(0)
@@ -285,10 +285,10 @@ RSpec.describe 'murano status', :cmd, :needs_password do
       expect(olines[0]).to eq("Only on local machine:\n")
       match_syncable_contents_except_singleRoute(olines[1..7])
       expect(olines[8]).to eq("Only on remote server:\n")
-      match_remote_boilerplate_v1_0_0_service(olines[9..32])
-      expect(olines[33]).to eq("Nothing that differs\n")
-      #expect(olines[33]).to eq("Items that differ:\n")
-      #expect(olines[34..34]).to contain_exactly(
+      match_remote_boilerplate_v1_0_0_service(olines[9..11])
+      expect(olines[12]).to eq("Nothing that differs\n")
+      #expect(olines[11]).to eq("Items that differ:\n")
+      #expect(olines[12..12]).to contain_exactly(
       #  a_string_matching(/ M E  .*services\/devdata\.lua/),
       #)
       expect(status.exitstatus).to eq(0)

--- a/spec/fixtures/dumped_config
+++ b/spec/fixtures/dumped_config
@@ -32,7 +32,7 @@ ignoring = *_test.lua *_spec.lua .*
 [eventhandler]
 searchFor = *.lua */*.lua {../eventhandlers,../event_handler}/*.lua {../eventhandlers,../event_handler}/*/*.lua
 ignoring = *_test.lua *_spec.lua .*
-skiplist = websocket webservice device.service_call
+skiplist = websocket webservice device.service_call interface device2.event
 
 [modules]
 searchFor = *.lua */*.lua


### PR DESCRIPTION
## Tickets

### MUR-3420: "ADC Device event handler is not firing".

- Looking at the Seed App instructions, I believe the interface services are being clobbered, since the instructions do not use "murano init" nor "murano syncdown" before doing a syncup.
- I added "interface" to the `eventhandler.skiplist` config setting, so these services will not be synced or clobbered.

### MRMUR-126: "MuranoCLI show command is not working"

- Fixed.

## Miscellaneous

### Bugfix: `murano init` broken when no solutions exist

- Fixed

### Exit immediately if token not retrieved

- Rather than chugging along and failing unexpectedly later.

### Bugfix: `murano solutions list` broken.

- Was treating Solution as Hash instead of class instance.

