### PR TITLE
Undeletable Event handlers and Nested Lua support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.31 /coding: utf-8
+# Last Modified: 2017.08.03 /coding: utf-8
 # Copyright © 2016-2017 Exosite LLC.
 # License: MIT. See LICENSE.txt.
 #  vim:tw=0:ts=2:sw=2:et:ai
@@ -101,6 +101,7 @@ Style/FileName:
   Exclude:
     - 'Gemfile'
     - 'MuranoCLI.gemspec'
+    - 'Rakefile'
     - 'lib/MrMurano.rb'
     - 'lib/MrMurano/Account.rb'
     - 'lib/MrMurano/Business.rb'
@@ -140,6 +141,14 @@ Style/NumericPredicate:
 Style/RaiseArgs:
   EnforcedStyle: compact
 
+# "Use // around regular expression."
+#Style/RegexpLiteral:
+#  # If "slashes" or "mixed":
+#  #   snake_case = /^[\dA-Z_]+$/
+#  # If "percent_r":
+#  #   snake_case = %r{^[\dA-Z_]+$}
+#  EnforcedStyle: percent_r
+
 # "Avoid comma after the last parameter of a method call."
 # FIXME/2017-06-30: Is this okay?
 Style/TrailingCommaInArguments:
@@ -167,7 +176,7 @@ AllCops:
     - 'bin/murano'
     # These are included by default:
     #- '**/Gemfile'
-    #- '**/Rakefile'
+    - '**/Rakefile'
     #- 'MuranoCLI.gemspec'
   # FIXME/2017-07-25: Finishing linting all the files!
   #   These files have not been linted since Rubocop was adopted.
@@ -178,10 +187,6 @@ AllCops:
     # 2017-07-25: It's probably not worth our time to lint the spec tests.
     # 2017-07-31: 7735 offenses in the Spec tests -- not worth it to fix!!
     - 'spec/**/*'
-    #
-    # FIXME/2017-07-25: Enable Rakefile check! [Currently: 106 offenses]
-    # 2017-07-31: 122 offenses in the Rakefile.
-    - '**/Rakefile'
     #
     # FIXME/2017-07-25: Finish linting these files, and delete from this list.
     # 2017-07-31: 943 offenses herein these 26 files.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.03 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # Copyright © 2016-2017 Exosite LLC.
 # License: MIT. See LICENSE.txt.
 #  vim:tw=0:ts=2:sw=2:et:ai
@@ -141,13 +141,23 @@ Style/NumericPredicate:
 Style/RaiseArgs:
   EnforcedStyle: compact
 
+# "Don't use parentheses around a literal."
+# How else do you split long lines, eh? E.g.,
+#   unbelievably_long_variable_name = (
+#     "Some very long sentence about being a very long sentence."
+#   )
+Style/RedundantParentheses:
+  Enabled: false
+
 # "Use // around regular expression."
+# "Use %r around regular expression."
 #Style/RegexpLiteral:
 #  # If "slashes" or "mixed":
 #  #   snake_case = /^[\dA-Z_]+$/
 #  # If "percent_r":
 #  #   snake_case = %r{^[\dA-Z_]+$}
-#  EnforcedStyle: percent_r
+#  #EnforcedStyle: percent_r
+#  EnforcedStyle: slashes
 
 # "Avoid comma after the last parameter of a method call."
 # FIXME/2017-06-30: Is this okay?

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.07 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -32,8 +32,8 @@ task :'install:user' do
   sh %(gem install -i #{Gem.dir} #{built_gem})
 end
 
-desc 'Uninstall gem from chruby directory'
-task :chuninstall do
+desc 'Uninstall gem from user gems directory'
+task :'uninstall:user' do
   # HINT: Replace #{built_gem} with any version to uninstall a specific version.
   # MAYBE/2017-08-04: A task to uninstall all installed versions?
   sh %(gem uninstall --version #{built_gem})
@@ -74,6 +74,11 @@ task :rspec do
 end
 task test: %i[test_clean_up rspec]
 
+desc 'Run Rubocop linter'
+task :rubocop do
+  sh %(rubocop -D -c .rubocop.yml)
+end
+
 desc 'Clean out junk from prior hot tests'
 task :test_clean_up do
   unless ENV['MURANO_CONFIGFILE'].nil?
@@ -84,6 +89,10 @@ task :test_clean_up do
     #    sh %(ruby -Ilib bin/murano solution delete #{id})
     #  end
     #end
+    # rubocop:disable Style/BlockDelimiters
+    #   "Prefer {...} over do...end for single-line blocks."
+    # Substituting braces for the do/end causes another problem:
+    #   "syntax error, unexpected '{', expecting keyword_end"
     sh %(ruby -Ilib bin/murano solutions expunge -y) do |_ok, _res| end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,10 +24,12 @@ task :unbob do
   sh %(gem uninstall --user-install #{built_gem})
 end
 
-desc 'Install gem to chruby directory'
-task :rebuild do
+desc 'Build and install into user gems directory (useful for rvm and chruby)'
+task :'install:user' do
   sh %(rake build)
-  sh %(gem install -i #{Bundler::GemHelper.gemspec.base_dir} #{built_gem})
+  # Bundler::GemHelper.gemspec.base_dir is the base of the project,
+  # and not the base of the gem directory.
+  sh %(gem install -i #{Gem.dir} #{built_gem})
 end
 
 desc 'Uninstall gem from chruby directory'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.04 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -25,7 +25,8 @@ task :unbob do
 end
 
 desc 'Install gem to chruby directory'
-task :chinstall do
+task :rebuild do
+  sh %(rake build)
   sh %(gem install -i #{Bundler::GemHelper.gemspec.base_dir} #{built_gem})
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -62,13 +62,14 @@ task test: %i[test_clean_up rspec]
 desc 'Clean out junk from prior hot tests'
 task :test_clean_up do
   unless ENV['MURANO_CONFIGFILE'].nil?
-    ids = `ruby -Ilib bin/murano solution list --idonly`.chomp
-    unless ids.empty?
-      puts "Found solutions #{ids}; deleting"
-      ids.split.each do |id|
-        sh %(ruby -Ilib bin/murano solution delete #{id})
-      end
-    end
+    #ids = `ruby -Ilib bin/murano solution list --idonly`.chomp
+    #unless ids.empty?
+    #  puts "Found solutions #{ids}; deleting"
+    #  ids.split.each do |id|
+    #    sh %(ruby -Ilib bin/murano solution delete #{id})
+    #  end
+    #end
+    sh %(ruby -Ilib bin/murano solutions expunge -y) do |_ok, _res| end
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.03 /coding: utf-8
+# Last Modified: 2017.08.04 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -22,6 +22,18 @@ end
 desc 'Uninstall from user dir'
 task :unbob do
   sh %(gem uninstall --user-install #{built_gem})
+end
+
+desc 'Install gem to chruby directory'
+task :chinstall do
+  sh %(gem install -i #{Bundler::GemHelper.gemspec.base_dir} #{built_gem})
+end
+
+desc 'Uninstall gem from chruby directory'
+task :chuninstall do
+  # HINT: Replace #{built_gem} with any version to uninstall a specific version.
+  # MAYBE/2017-08-04: A task to uninstall all installed versions?
+  sh %(gem uninstall --version #{built_gem})
 end
 
 task :echo do

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -204,6 +204,8 @@ Run these commands once from any directory:
 
     gem install byebug
 
+    gem install rubocop
+
 Prepare MuranoCLI
 -----------------
 

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.27 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -126,6 +126,10 @@ Or set your password with `murano password set <username>`.
       else
         showHttpError(request, response)
         error 'Check to see if username and password are correct.'
+        unless ENV['MURANO_PASSWORD'].to_s.empty?
+          pwd_path = $cfg.file_at('passwords', :user)
+          warning "BEWARE: The password used was from MURANO_PASSWORD, not from #{pwd_path}"
+        end
         @token = nil
       end
     end

--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -200,6 +200,13 @@ module MrMurano
         webservice
         websocket
       ].join(' '), :defaults)
+      # Do not delete boilerplate event handlers.
+      set('eventhandler.undeletable', %w[
+        *.event
+        timer.timer
+        tsdb.exportJob
+        user.account
+      ].join(' '), :defaults)
 
       set('modules.searchFor', %w[
         *.lua

--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.02 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -135,6 +135,10 @@ module MrMurano
       # The user can exclude certain scopes.
       @exclude_scopes = []
 
+      set_defaults
+    end
+
+    def set_defaults
       # All these set()'s are against the :defaults config.
       # So no disk writing ensues. And these serve as defaults
       # unless, say, a SolutionFile says otherwise.
@@ -161,19 +165,51 @@ module MrMurano
       set('files.searchFor', '**/*', :defaults)
       set('files.ignoring', '', :defaults)
 
-      set('endpoints.searchFor', '{,../endpoints}/*.lua {,../endpoints}s/*/*.lua', :defaults)
-      set('endpoints.ignoring', '*_test.lua *_spec.lua .*', :defaults)
+      set('endpoints.searchFor', %w[
+        {,../endpoints}/*.lua
+        {,../endpoints}s/*/*.lua
+      ].join(' '), :defaults)
+      set('endpoints.ignoring', %w[
+        *_test.lua
+        *_spec.lua
+        .*
+      ].join(' '), :defaults)
 
-      set(
-        'eventhandler.searchFor',
-        '*.lua */*.lua {../eventhandlers,../event_handler}/*.lua {../eventhandlers,../event_handler}/*/*.lua',
-        :defaults,
-      )
-      set('eventhandler.ignoring', '*_test.lua *_spec.lua .*', :defaults)
-      set('eventhandler.skiplist', 'websocket webservice device.service_call interface device2.event', :defaults)
+      set('eventhandler.searchFor', %w[
+        *.lua
+        */*.lua
+        {../eventhandlers,../event_handler}/*.lua
+        {../eventhandlers,../event_handler}/*/*.lua
+      ].join(' '), :defaults)
+      set('eventhandler.ignoring', %w[
+        *_test.lua
+        *_spec.lua
+        .*
+      ].join(' '), :defaults)
+      # 2017-08-07: device.datapoint is the v1 device event handler.
+      #   It is deprecated and will be removed in 12 months.
+      #   So it technically still works, but eventually will not.
+      # device2.event is the event handler that is created when two solutions
+      #   are linked (say, an application and a product). Do not delete this.
+      # The interface service contains lots of simple device event handlers
+      #   that we don't want to touch.
+      set('eventhandler.skiplist', %w[
+        device.service_call
+        device2.event
+        interface
+        webservice
+        websocket
+      ].join(' '), :defaults)
 
-      set('modules.searchFor', '*.lua **/*.lua', :defaults)
-      set('modules.ignoring', '*_test.lua *_spec.lua .*', :defaults)
+      set('modules.searchFor', %w[
+        *.lua
+        **/*.lua
+      ].join(' '), :defaults)
+      set('modules.ignoring', %w[
+        *_test.lua
+        *_spec.lua
+        .*
+      ].join(' '), :defaults)
 
       if Gem.win_platform?
         set('diff.cmd', 'fc', :defaults)

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.03 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -121,7 +121,7 @@ module MrMurano
       end
 
       def self.description
-        %(Resources)
+        %(Resource)
       end
 
       def list
@@ -321,10 +321,10 @@ module MrMurano
       end
     end
     # 2017-07-18: Against OneP, fetching --resources is expensive, so this
-    # call was ignored bydefault (you'd have to add --resources to syncup,
-    # syncdown, diff, and status commands). Against Murano, this call seems
-    # normal speed, so including by default.
-    SyncRoot.instance.add('resources', Resources, 'T', true)
+    #   call was ignored bydefault (you'd have to add --resources to syncup,
+    #   syncdown, diff, and status commands). Against Murano, this call seems
+    #   normal speed, so including by default.
+    SyncRoot.instance.add('resources', Resources, 'T', true, %w[specs])
 
     ##############################################################################
     ##

--- a/lib/MrMurano/ReCommander.rb
+++ b/lib/MrMurano/ReCommander.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.26 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -80,17 +80,21 @@ module Commander
 
       begin
         old_run_active_command
-      rescue MrMurano::ConfigError => err
-        # Clear whirly if it was running.
-        MrMurano::Verbose.whirly_stop
-        MrMurano::Verbose.error err.message
-        exit 1
       rescue LocalJumpError => _err
         # This happens when you `return` from a command, since
         # commands are blocks, and returning from a block would
         # really mean returning from the thing running the block,
         # which would be bad. So Ruby barfs instead.
         return
+      rescue OptionParser::InvalidOption => err
+        MrMurano::Verbose.whirly_stop
+        MrMurano::Verbose.error err.message
+        exit 1
+      rescue MrMurano::ConfigError => err
+        # Clear whirly if it was running.
+        MrMurano::Verbose.whirly_stop
+        MrMurano::Verbose.error err.message
+        exit 1
       rescue StandardError => _err
         raise
       end

--- a/lib/MrMurano/Solution-ServiceConfig.rb
+++ b/lib/MrMurano/Solution-ServiceConfig.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.07 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -24,10 +24,9 @@ module MrMurano
 
     def search(svc_name)
       #path = nil
-      #path = '?select=id,service,script_key'
-      # 2017-07-02: This is what yeti-ui adds.
-      # FIXME/EXPLAIN/2017-07-02: What's "UUID" that web UI uses?
-      path = '?select=service,id,solution_id,script_key,alias'
+      path = '?select=id,service,script_key'
+      # 2017-07-02: This is what yeti-ui queries on:
+      #path = '?select=service,id,solution_id,script_key,alias'
       super(svc_name, path)
     end
 

--- a/lib/MrMurano/Solution-ServiceConfig.rb
+++ b/lib/MrMurano/Solution-ServiceConfig.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.25 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -12,7 +12,7 @@ module MrMurano
   class ServiceConfig < SolutionBase
     def initialize(sid=nil)
       super
-      @uriparts << 'serviceconfig'
+      @uriparts << :serviceconfig
       @scid = nil
     end
 
@@ -111,7 +111,7 @@ module MrMurano
   class Services < SolutionBase
     def initialize(sid=nil)
       super
-      @uriparts << 'service'
+      @uriparts << :service
     end
 
     def sid_for_name(name)

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -5,6 +5,7 @@
 # License: MIT. See LICENSE.txt.
 #  vim:tw=0:ts=2:sw=2:et:ai
 
+require 'abbrev'
 require 'cgi'
 require 'date'
 require 'digest/sha1'
@@ -55,28 +56,33 @@ module MrMurano
     end
 
     # @param modify Bool: True if item exists already and this is changing it
-    def upload(local, remote, _modify=false)
-      local = Pathname.new(local) unless local.is_a?(Pathname)
-      raise 'no file' unless local.exist?
-
-      # we assume these are small enough to slurp.
-      script = local.read
-
-      pst = remote.to_h.merge(
+    def upload(localpath, thereitem, _modify=false)
+      localpath = Pathname.new(localpath) unless localpath.is_a?(Pathname)
+      if localpath.exist?
+        # we assume these are small enough to slurp.
+        script = localpath.read
+      else
+        # I.e., thereitem.phantom, an "undeletable" file that does not
+        # exist locally but should not be deleted from server.
+        raise 'no file' unless thereitem.script
+        script = thereitem.script
+      end
+      localpath = Pathname.new(localpath) unless localpath.is_a?(Pathname)
+      name = mkname(thereitem)
+      pst = thereitem.to_h.merge(
         #solution_id: $cfg[@solntype],
         solution_id: @sid,
         script: script,
-        alias: mkalias(remote),
-        name: mkname(remote),
+        alias: mkalias(thereitem),
+        name: name,
       )
-      debug "f: #{local} >> #{pst.reject { |k, _| k == :script }.to_json}"
+      debug "f: #{localpath} >> #{pst.reject { |k, _| k == :script }.to_json}"
       # Try PUT. If 404, then POST.
       # I.e., PUT if not exists, else POST to create.
       updated_at = nil
-      put('/' + mkalias(remote), pst) do |request, http|
+      put('/' + mkalias(thereitem), pst) do |request, http|
         response = http.request(request)
-        _isj, jsn = isJSON(response.body)
-        if response == Net::HTTPSuccess
+        if response.is_a?(Net::HTTPSuccess)
           # A first upload will see a 200 response and a JSON body.
           # A subsequent upload of the same item sees 204 and no body.
           #return JSON.parse(response.body)
@@ -86,34 +92,42 @@ module MrMurano
           verbose "Doesn't exist, creating"
           post('/', pst)
         else
-          relpath = local.sub(File.join(Dir.pwd, ''), '')
-          if Net::HTTPBadRequest && _isj && jsn[:message] == "Validation errors"
+          relpath = localpath.sub(File.join(Dir.pwd, ''), '')
+          if response.is_a?(Net::HTTPBadRequest) && isj && jsn[:message] == 'Validation errors'
             warning "Validation errors detected in #{relpath}:"
-            puts MrMurano::Pretties::makeJsonPretty(jsn[:errors], Struct.new(:pretty).new(true))
+            puts MrMurano::Pretties.makeJsonPretty(jsn[:errors], Struct.new(:pretty).new(true))
           else
             showHttpError(request, response)
           end
           warning "Failed to upload: #{relpath}"
         end
       end
-      cache_update_time_for(local, updated_at)
+      cache_update_time_for(localpath, updated_at)
     end
 
     def docmp(item_a, item_b)
       if item_a[:updated_at].nil? && item_a[:local_path]
         ct = cached_update_time_for(item_a[:local_path])
         item_a[:updated_at] = ct unless ct.nil?
-        item_a[:updated_at] = item_a[:local_path].mtime.getutc if ct.nil?
+        # The item might not exist if it was resurrected (item.phantom).
+        if ct.nil? && item_a[:local_path].exist?
+          item_a[:updated_at] = item_a[:local_path].mtime.getutc
+        end
       elsif item_a[:updated_at].is_a?(String)
         item_a[:updated_at] = DateTime.parse(item_a[:updated_at]).to_time.getutc
       end
       if item_b[:updated_at].nil? && item_b[:local_path]
         ct = cached_update_time_for(item_b[:local_path])
         item_b[:updated_at] = ct unless ct.nil?
-        item_b[:updated_at] = item_b[:local_path].mtime.getutc if ct.nil?
+        if ct.nil? && item_b[:local_path].exist?
+          item_b[:updated_at] = item_b[:local_path].mtime.getutc
+        end
       elsif item_b[:updated_at].is_a?(String)
         item_b[:updated_at] = DateTime.parse(item_b[:updated_at]).to_time.getutc
       end
+      return false if item_a[:updated_at].nil? && item_b[:updated_at].nil?
+      return true if item_a[:updated_at].nil? && !item_b[:updated_at].nil?
+      return true if !item_a[:updated_at].nil? && item_b[:updated_at].nil?
       item_a[:updated_at].to_time.round != item_b[:updated_at].to_time.round
     end
 
@@ -142,8 +156,9 @@ module MrMurano
       elsif time.is_a?(String)
         time = DateTime.parse(time)
       end
+      file_hash = local_path_file_hash(local_path)
       entry = {
-        sha1: Digest::SHA1.file(local_path.to_s).hexdigest,
+        sha1: file_hash,
         updated_at: time.to_datetime.iso8601(3),
       }
       cache_file = $cfg.file_at(cache_file_name)
@@ -168,7 +183,7 @@ module MrMurano
     end
 
     def cached_update_time_for(local_path)
-      cksm = Digest::SHA1.file(local_path.to_s).hexdigest
+      cksm = local_path_file_hash(local_path)
       cache_file = $cfg.file_at(cache_file_name)
       return nil unless cache_file.file?
       ret = nil
@@ -189,6 +204,17 @@ module MrMurano
         end
       end
       ret
+    end
+
+    def local_path_file_hash(local_path)
+      if local_path.exist?
+        Digest::SHA1.file(local_path.to_s).hexdigest
+      else
+        # For item.phantom. Return the empty string, hashed:
+        #   da39a3ee5e6b4b0d3255bfef95601890afd80709
+        Digest::SHA1.hexdigest('')
+        # MAYBE: Pass in the item and check for item.script?
+      end
     end
   end
 
@@ -266,12 +292,14 @@ module MrMurano
       attr_accessor :created_at
       # @return [String] The soln's product.id or application.id (Murano's apiId).
       attr_accessor :solution_id
-      # @return [String] Which service triggers this script
+      # @return [String] Which service triggers this script.
       attr_accessor :service
-      # @return [String] Which event triggers this script
+      # @return [String] Which event triggers this script.
       attr_accessor :event
-      # @return [String] For device2 events, the type of event
+      # @return [String] For device2 events, the type of event.
       attr_accessor :type
+      # @return [Boolean] True if local phantom item via eventhandler.undeletable.
+      attr_accessor :phantom
     end
 
     def initialize(sid=nil)
@@ -301,16 +329,33 @@ module MrMurano
       # fe: service.event service service service.event
       skiplist = ($cfg['eventhandler.skiplist'] || '').split
       items = ret[:items].reject do |item|
-        toss = (
-          item.key?(:service) &&
-          item.key?(:event) && (
-            skiplist.include?(item[:service]) ||
-            skiplist.include?("#{item[:service]}.#{item[:event]}")
-          )
-        )
+        toss = skip?(item, skiplist)
+        debug "skiplist excludes: #{item[:service]}.#{item[:event]}" if toss
         toss
       end
       items.map { |item| EventHandlerItem.new(item) }
+    end
+
+    def skip?(item, skiplist)
+      return false unless item.key?(:service) && item.key?(:event)
+      skiplist.any? do |svc_evt|
+        cmp_svc_evt(item, svc_evt)
+      end
+    end
+
+    def cmp_svc_evt(item, svc_evt)
+      service, event = svc_evt.split('.', 2)
+      if event.nil? || item[:event] == '*'
+        service == item[:service]
+      else
+        # rubocop:disable Style/IfInsideElse
+        #svc_evt == "#{item[:service]}.#{item[:event]}"
+        if service == '*'
+          event == item[:event]
+        else
+          service == item[:service] && event == item[:event]
+        end
+      end
     end
 
     def fetch(name)
@@ -426,6 +471,41 @@ module MrMurano
 
     def synckey(item)
       "#{item[:service]}_#{item[:event]}"
+    end
+
+    def resurrect_undeletables(localbox, therebox)
+      undeletables = ($cfg['eventhandler.undeletable'] || '').split
+      (therebox.keys - localbox.keys).each do |key|
+        # key exists in therebox but not localbox.
+        thereitem = therebox[key]
+        next unless undeletable?(thereitem, undeletables)
+        debug "Undeletable: #{key}"
+        undeletable = EventHandlerItem.new(thereitem)
+        undeletable.id = nil
+        undeletable.created_at = nil
+        undeletable.updated_at = nil
+        #undeletable.local_path
+        #undeletable.line
+        # Even if the user deletes the contents of a script,
+        # the platform still sends the magic header.
+        #undeletable.script = ''
+        undeletable.script = (
+          "--#EVENT #{therebox[key].service} #{therebox[key].event}\n"
+        )
+        undeletable.local_path = Pathname.new(
+          File.join(location, tolocalname(thereitem, key))
+        )
+        undeletable.phantom = true
+        localbox[key] = undeletable
+      end
+      localbox
+    end
+
+    def undeletable?(item, undeletables)
+      return false if item.service.to_s.empty? || item.event.to_s.empty?
+      undeletables.any? do |svc_evt|
+        cmp_svc_evt(item, svc_evt)
+      end
     end
   end
 

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.31 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -192,7 +192,7 @@ module MrMurano
       # FIXME/VERIFY/2017-07-02: Check that products do not have Modules.
       @solntype = 'application.id'
       super
-      @uriparts << 'module'
+      @uriparts << :module
       @itemkey = :alias
       @project_section = :modules
     end
@@ -258,7 +258,7 @@ module MrMurano
 
     def initialize(sid=nil)
       super
-      @uriparts << 'eventhandler'
+      @uriparts << :eventhandler
       @itemkey = :alias
       #@project_section = :services
       raise 'Subclass missing @project_section' unless @project_section

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -117,6 +117,16 @@ module MrMurano
       item_a[:updated_at].to_time.round != item_b[:updated_at].to_time.round
     end
 
+    def dodiff(merged, local, there, asdown=false)
+      mrg_diff = super
+      if mrg_diff.empty?
+        mrg_diff = '<Nothing changed (was timestamp difference)>'
+        # FIXME/2017-08-08: This isn't exactly working: setting mtime...
+        cache_update_time_for(local.local_path, there.updated_at)
+      end
+      mrg_diff
+    end
+
     def cache_file_name
       [
         'cache',

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.07 /coding: utf-8
+# Last Modified: 2017.08.09 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -217,7 +217,7 @@ module MrMurano
 
     def self.description
       # MAYBE/2017-07-31: Rename to "Script Modules", per Renaud's suggestion? [lb]
-      %(Modules)
+      %(Module)
     end
 
     def tolocalname(item, _key)
@@ -442,7 +442,7 @@ module MrMurano
     end
 
     def self.description
-      %(Product Event Handlers)
+      %(Interface)
     end
 
     ##
@@ -476,7 +476,7 @@ module MrMurano
     end
 
     def self.description
-      %(Application Event Handlers)
+      %(Service)
     end
 
     ##
@@ -492,11 +492,16 @@ module MrMurano
   end
 
   # Order here matters, because spec/cmd_init_spec.rb
-  SyncRoot.instance.add('eventhandlers', EventHandlerSolnApp, 'E', true)
-  SyncRoot.instance.add('eventhandlers', EventHandlerSolnPrd, 'E', true)
-  # FIXME/2017-06-20: Should we use separate directories for prod vs app?
-  #   [lb] thinks so if the locallist/PRODUCT_SERVICES kludge fails in the future.
-  #SyncRoot.instance.add('services', EventHandlerSolnApp, 'E', true)
-  #SyncRoot.instance.add('interfaces', EventHandlerSolnPrd, 'E', true)
+  # NOTE/2017-08-07: There was one syncable in 2.x for events, but in ADC,
+  #   there are different events for Applications and Products.
+  #   Except there aren't any product events the user should care about (yet?).
+  SyncRoot.instance.add(
+    'eventhandlers', EventHandlerSolnApp, 'E', true, %w[services]
+  )
+  # 2017-08-08: device2 and interface are now part of the skiplist, so no
+  # product event handlers will be found, unless the user modifies the skiplist.
+  SyncRoot.instance.add(
+    'interfaces', EventHandlerSolnPrd, 'I', true, %w[]
+  )
 end
 

--- a/lib/MrMurano/Solution-Users.rb
+++ b/lib/MrMurano/Solution-Users.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.26 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -119,7 +119,7 @@ module MrMurano
       @solntype = 'application.id'
       #@solntype = 'product.id'
       super
-      @uriparts << 'role'
+      @uriparts << :role
       @itemkey = :role_id
     end
 
@@ -138,7 +138,7 @@ module MrMurano
       @solntype = 'application.id'
       #@solntype = 'product.id'
       super
-      @uriparts << 'user'
+      @uriparts << :user
     end
 
     def self.description

--- a/lib/MrMurano/Solution-Users.rb
+++ b/lib/MrMurano/Solution-Users.rb
@@ -148,7 +148,7 @@ module MrMurano
     # @param modify Bool: True if item exists already and this is changing it
     def upload(_local, _remote, _modify)
       # TODO: figure out APIs for updating users.
-      warning %(Updating Users isn't working currently.)
+      warning %(Updating Users is not yet implemented.)
       # post does work if the :password field is set.
     end
 

--- a/lib/MrMurano/Solution-Users.rb
+++ b/lib/MrMurano/Solution-Users.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.07 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -124,7 +124,7 @@ module MrMurano
     end
 
     def self.description
-      %(Roles)
+      %(Role)
     end
   end
   #SyncRoot.instance.add('roles', Role, 'R', false)
@@ -142,7 +142,7 @@ module MrMurano
     end
 
     def self.description
-      %(Users)
+      %(User)
     end
 
     # @param modify Bool: True if item exists already and this is changing it

--- a/lib/MrMurano/Solution.rb
+++ b/lib/MrMurano/Solution.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.26 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -59,6 +59,13 @@ module MrMurano
         ret = super
         if ret.nil? && !@suppress_error
           warning "No solution with ID: #{@sid}"
+          whirly_interject { say 'Run `murano show` to see the business and list of solutions.' }
+          if true \
+            && !$cfg.get('business.id', :env).to_s.empty? \
+            && !$cfg.get('business.id', :project).to_s.empty? \
+            && $cfg.get('business.id', :env) != $cfg.get('business.id', :project)
+          end
+          warning "NOTE: MURANO_CONFIGFILE specifies a different business.id than the local project file"
           exit 1
         end
         return nil if ret.nil?

--- a/lib/MrMurano/Solution.rb
+++ b/lib/MrMurano/Solution.rb
@@ -60,12 +60,11 @@ module MrMurano
         if ret.nil? && !@suppress_error
           warning "No solution with ID: #{@sid}"
           whirly_interject { say 'Run `murano show` to see the business and list of solutions.' }
-          if true \
-            && !$cfg.get('business.id', :env).to_s.empty? \
-            && !$cfg.get('business.id', :project).to_s.empty? \
-            && $cfg.get('business.id', :env) != $cfg.get('business.id', :project)
+          if $cfg.get('business.id', :env).to_s.empty? &&
+             $cfg.get('business.id', :project).to_s.empty? &&
+             $cfg.get('business.id', :env) != $cfg.get('business.id', :project)
+            warning 'NOTE: MURANO_CONFIGFILE specifies a different business.id than the local project file'
           end
-          warning "NOTE: MURANO_CONFIGFILE specifies a different business.id than the local project file"
           exit 1
         end
         return nil if ret.nil?

--- a/lib/MrMurano/SyncRoot.rb
+++ b/lib/MrMurano/SyncRoot.rb
@@ -78,7 +78,8 @@ module MrMurano
     # Iterate over all syncables with option arguments.
     # @param block code to run on each
     def each_option
-      @syncset.each { |a| yield "-#{a.type.downcase}", "--[no-]#{a.name}", a.desc }
+      #@syncset.each { |a| yield "-#{a.type.downcase}", "--[no-]#{a.name}", a.desc }
+      @syncset.each { |a| yield "-#{a.type}", "--[no-]#{a.name}", a.desc }
     end
 
     ##

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.31 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -338,9 +338,8 @@ module MrMurano
         # Check the platform, e.g., "linux-gnu", or other.
         is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
         unless is_windows
-          $stderr.puts(
-            "Unexpected: touch failed on non-Windows machine / host_os: #{RbConfig::CONFIG['host_os']} / err: #{err}"
-          )
+          msg = "Unexpected: touch failed on non-Windows machine"
+          $stderr.puts("#{msg} / host_os: #{RbConfig::CONFIG['host_os']} / err: #{err}")
         end
 
         # 2017-07-13: Nor does ctime work.

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -8,6 +8,7 @@
 # FIXME/MAYBE: Fix semicolon usage.
 # rubocop:disable Style/Semicolon
 
+require 'inflecto'
 require 'open3'
 require 'pathname'
 #require 'shellwords'
@@ -494,7 +495,9 @@ module MrMurano
           #     Skipping missing location ‘/tmp/d20170731-3150-1f50uj4/project/specs/resources.yaml’ (Resources)
           #   but then later in the syncdown, that directory and file gets created.
           msg = "Skipping missing location ‘#{location}’"
-          msg += " (#{self.class.description})" unless self.class.description.to_s.empty?
+          unless self.class.description.to_s.empty?
+            msg += " (#{Inflecto.pluralize(self.class.description)})"
+          end
           warning(msg)
           @missing_complaints << location
         end

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -330,7 +330,8 @@ module MrMurano
       #   (See more comments, below.)
       return unless item[:updated_at]
 
-      mod_time = DateTime.parse(item[:updated_at]).to_time
+      mod_time = item[:updated_at]
+      mod_time = DateTime.parse(mod_time).to_time unless mod_time.is_a?(Time)
       begin
         FileUtils.touch([local.to_path], mtime: mod_time)
       rescue Errno::EACCES => err

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.07 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -14,7 +14,7 @@ require 'pathname'
 require 'tempfile'
 require 'MrMurano/progress'
 require 'MrMurano/verbosing'
-#require 'MrMurano/hash'
+require 'MrMurano/hash'
 #require 'MrMurano/Config'
 #require 'MrMurano/ProjectFile'
 ##require 'MrMurano/SyncRoot'
@@ -563,27 +563,8 @@ module MrMurano
       items.flatten.compact
     end
 
-    #######################################################################
-    # Methods that provide the core status/syncup/syncdown
-
-    ##
-    # Take a hash or something (a Commander::Command::Options) and return a hash
-    #
-    # @param hsh [Hash, Commander::Command::Options] Thing we want to be a Hash
-    # @return [Hash] an actual Hash with default value of false
-    def elevate_hash(hsh)
-      # Commander::Command::Options stripped all of the methods from parent
-      # objects. I have not nice thoughts about that.
-      begin
-        hsh = hsh.__hash__
-      # rubocop:disable Lint/HandleExceptions: Do not suppress exceptions.
-      rescue NoMethodError
-        # swallow this.
       end
-      # build a hash where the default is 'false' instead of 'nil'
-      Hash.new(false).merge(Hash.transform_keys_to_symbols(hsh))
     end
-    private :elevate_hash
 
     def sync_update_progress(msg)
       if $cfg['tool.no-progress']

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -722,7 +722,7 @@ module MrMurano
     # @param merged [merged] The merged item to get a diff of
     # @local local, unadulterated (non-merged) item
     # @return [String] The diff output
-    def dodiff(merged, local, asdown=false)
+    def dodiff(merged, local, _there, asdown=false)
       trmt = Tempfile.new([tolocalname(merged, @itemkey) + '_remote_', '.lua'])
       tlcl = Tempfile.new([tolocalname(merged, @itemkey) + '_local_', '.lua'])
       Pathname.new(tlcl.path).open('wb') do |io|
@@ -910,8 +910,7 @@ module MrMurano
 
         if docmp(localbox[key], therebox[key])
           if options[:diff] && mrg[:selected]
-            mrg[:diff] = dodiff(mrg.to_h, localbox[key], options[:asdown])
-            mrg[:diff] = '<Nothing changed (may be timestamp difference?)>' if mrg[:diff].empty?
+            mrg[:diff] = dodiff(mrg.to_h, localbox[key], therebox[key], options[:asdown])
           end
           tomod << mrg
         else

--- a/lib/MrMurano/Webservice-Cors.rb
+++ b/lib/MrMurano/Webservice-Cors.rb
@@ -7,7 +7,7 @@ module MrMurano
     class Settings < WebserviceBase
       def initialize
         super
-        @uriparts << 'cors'
+        @uriparts << :cors
       end
       def cors
         ret = get('')
@@ -24,7 +24,7 @@ module MrMurano
     class Cors < WebserviceBase
       def initialize
         super
-        @uriparts << 'cors'
+        @uriparts << :cors
         #@project_section = :cors
       end
 

--- a/lib/MrMurano/Webservice-Endpoint.rb
+++ b/lib/MrMurano/Webservice-Endpoint.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.26 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -31,7 +31,7 @@ module MrMurano
 
       def initialize
         super
-        @uriparts << 'endpoint'
+        @uriparts << :endpoint
         @project_section = :routes
         @match_header = /--#ENDPOINT (?<method>\S+) (?<path>\S+)( (?<ctype>.*))?/
       end

--- a/lib/MrMurano/Webservice-Endpoint.rb
+++ b/lib/MrMurano/Webservice-Endpoint.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.07 /coding: utf-8
+# Last Modified: 2017.08.09 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -37,7 +37,9 @@ module MrMurano
       end
 
       def self.description
-        %(Endpoints)
+        # 2017-08-07: UI and ProjectFile call these "Routes". Let's be consistent.
+        #%(Endpoint)
+        %(Route)
       end
 
       ##
@@ -217,7 +219,7 @@ module MrMurano
       end
     end
 
-    SyncRoot.instance.add('endpoints', Endpoint, 'A', true)
+    SyncRoot.instance.add('endpoints', Endpoint, 'A', true, %w[routes])
   end
 end
 

--- a/lib/MrMurano/Webservice-File.rb
+++ b/lib/MrMurano/Webservice-File.rb
@@ -132,7 +132,7 @@ module MrMurano
           end
 
           response = http.request(request)
-          showHttpError(request, response) unless response == Net::HTTPSuccess
+          showHttpError(request, response) unless response.is_a?(Net::HTTPSuccess)
         end
       end
 

--- a/lib/MrMurano/Webservice-File.rb
+++ b/lib/MrMurano/Webservice-File.rb
@@ -37,7 +37,7 @@ module MrMurano
       def list
         ret = get()
         return [] if ret.is_a?(Hash) and ret.has_key?(:error)
-        ret.map{|i| FileItem.new(i)}
+        ret.map { |i| FileItem.new(i) }
       end
 
       ##
@@ -104,11 +104,11 @@ module MrMurano
         # Most of these pull into ram.  So maybe just go with that. Would guess that
         # truely large static content is rare, and we can optimize/fix that later.
 
-        file = HTTP::FormData::File.new(local.to_s, {:content_type=>remote[:mime_type]})
-        form = HTTP::FormData.create(:file=>file)
+        file = HTTP::FormData::File.new(local.to_s, { content_type: remote[:mime_type] })
+        form = HTTP::FormData.create(file: file)
         req = Net::HTTP::Put.new(uri)
         set_def_headers(req)
-        workit(req) do |request,http|
+        workit(req) do |request, http|
           request.content_type = form.content_type
           request.content_length = form.content_length
           request.body = form.to_s
@@ -129,11 +129,7 @@ module MrMurano
           end
 
           response = http.request(request)
-          case response
-          when Net::HTTPSuccess
-          else
-            showHttpError(request, response)
-          end
+          showHttpError(request, response) unless response == Net::HTTPSuccess
         end
       end
 

--- a/lib/MrMurano/Webservice-File.rb
+++ b/lib/MrMurano/Webservice-File.rb
@@ -28,7 +28,10 @@ module MrMurano
       end
 
       def self.description
-        %(Static Files)
+        # 2017-08-07: The UI calls these ASSETS in the tab
+        # (and refers to "Static file hosting").
+        #%(Static File)
+        %(Asset)
       end
 
       ##
@@ -181,7 +184,7 @@ module MrMurano
       end
     end
 
-    SyncRoot.instance.add('files', File, 'S', true)
+    SyncRoot.instance.add('files', File, 'S', true, %w[assets])
   end
 end
 #  vim: set ai et sw=2 ts=2 :

--- a/lib/MrMurano/Webservice-File.rb
+++ b/lib/MrMurano/Webservice-File.rb
@@ -22,7 +22,7 @@ module MrMurano
 
       def initialize
         super
-        @uriparts << 'file'
+        @uriparts << :file
         @itemkey = :path
         @project_section = :assets
       end

--- a/lib/MrMurano/commands/status.rb
+++ b/lib/MrMurano/commands/status.rb
@@ -1,12 +1,41 @@
-# Last Modified: 2017.07.26 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
 # License: MIT. See LICENSE.txt.
 #  vim:tw=0:ts=2:sw=2:et:ai
 
+require 'inflecto'
 require 'MrMurano/verbosing'
 require 'MrMurano/SyncRoot'
+
+# Load options to control which things to sync
+def command_add_syncable_options(cmd)
+  MrMurano::SyncRoot.instance.each_option do |short, long, desc|
+    cmd.option short, long, desc
+  end
+  MrMurano::SyncRoot.instance.each_alias do |long, desc|
+    cmd.option long, desc
+  end
+end
+
+def command_set_syncable_defaults(options)
+  # Weird. The options is a Commander::Command::Options object, but
+  # options.class says nil! Also, you cannot index properties or
+  # even options.send('opt'). But we can just twiddle the raw table.
+  table = options.__hash__
+  MrMurano::SyncRoot.instance.each_default do |osyn, oname|
+    syn = osyn.tr('-', '_').to_sym
+    name = oname.tr('-', '_').to_sym
+    unless table[syn].nil?
+      if table[name].nil?
+        table[name] = table[syn]
+      elsif table[name] != table[syn]
+        MrMurano::Verbose.warning("Ignoring --#{osyn} because --#{oname} also specified")
+      end
+    end
+  end
+end
 
 command :status do |c|
   c.syntax = %(murano status [options] [filters])
@@ -30,18 +59,15 @@ with the full file path.
 Each item type also supports specific filters. These always start with #.
 Endpoints can be selected with a "#<method>#<path glob>" pattern.
   ).gsub(/^ +/, '').strip
+
   c.option '--all', 'Check everything'
-
-  # Load options to control which things to status
-  MrMurano::SyncRoot.instance.each_option do |s, l, d|
-    c.option s, l, d
-  end
-
   c.option '--[no-]asdown', %(Report as if syncdown instead of syncup)
   c.option '--[no-]asup', %(Report as if syncup instead of syncdown (default: true))
   c.option '--[no-]diff', %(For modified items, show a diff)
   c.option '--[no-]grouped', %(Group all adds, deletes, and mods together)
-  c.option '--[no-]showall', %(List unchanged as well)
+  c.option '--[no-]show-all', %(List unchanged as well)
+  c.option '--[no-]show-type', %(Include type of item)
+  command_add_syncable_options(c)
 
   c.action do |args, options|
     options.default(
@@ -49,7 +75,8 @@ Endpoints can be selected with a "#<method>#<path glob>" pattern.
       asup: nil,
       diff: false,
       grouped: true,
-      showall: false,
+      show_all: false,
+      show_type: false,
       # delete/create/update are not options the user can specify
       # for status or diff commands; but the SyncUpDown class expects
       # them.
@@ -57,48 +84,76 @@ Endpoints can be selected with a "#<method>#<path glob>" pattern.
       create: true,
       update: true,
     )
+    command_set_syncable_defaults(options)
 
-    def fmtr(item)
-      if item.key? :local_path
-        lp = item[:local_path].relative_path_from(Pathname.pwd).to_s
-        return "#{lp}:#{item[:line]}" if item.key?(:line) && item[:line] > 0
-        lp
+    def fmtr(item, options)
+      if item.key?(:local_path)
+        if !item[:local_path].to_s.start_with?('/dev/null/')
+          desc = item[:local_path].relative_path_from(Pathname.pwd).to_s
+          desc = "#{desc}:#{item[:line]}" if item.key?(:line) && item[:line] > 0
+        else
+          # MAYBE: Indicate that the item doesn't really exist locally?
+          #desc = "#{item[:synckey]} [empty]"
+          desc = item[:synckey]
+        end
       else
-        id = item[:synckey]
-        id += " (#{item[:pp_desc]})" unless item[:pp_desc].to_s.empty? || item[:pp_desc] == item[:synckey]
-        id
+        desc = item[:synckey]
       end
+      return desc unless options.show_type
+      unless item[:pp_desc].to_s.empty? || item[:pp_desc] == item[:synckey]
+        desc += " (#{Inflecto.singularize(item[:pp_desc])})"
+      end
+      desc += " [#{item[:method]} #{item[:path]}]" if item[:method] && item[:path]
+      desc
+    end
+
+    def interject(msg)
+      MrMurano::Verbose.whirly_interject { say msg }
     end
 
     def pretty(ret, options)
-      pretty_group_header(ret[:toadd], 'Only on local machine', 'new locally', options.grouped)
-      ret[:toadd].each { |item| say " + #{item[:pp_type]}  #{highlight_chg(fmtr(item))}" }
+      pretty_group_header(
+        ret[:toadd], 'Only on local machine', 'new locally', options.grouped
+      )
+      ret[:toadd].each do |item|
+        interject " + #{item[:pp_type]}  #{highlight_chg(fmtr(item, options))}"
+      end
 
-      pretty_group_header(ret[:todel], 'Only on remote server', 'new remotely', options.grouped)
-      ret[:todel].each { |item| say " - #{item[:pp_type]}  #{highlight_del(fmtr(item))}" }
+      pretty_group_header(
+        ret[:todel], 'Only on remote server', 'new remotely', options.grouped
+      )
+      ret[:todel].each do |item|
+        interject " - #{item[:pp_type]}  #{highlight_del(fmtr(item, options))}"
+      end
 
-      pretty_group_header(ret[:tomod], 'Items that differ', 'that differs', options.grouped)
+      pretty_group_header(
+        ret[:tomod], 'Items that differ', 'that differs', options.grouped
+      )
       ret[:tomod].each do |item|
-        say " M #{item[:pp_type]}  #{highlight_chg(fmtr(item))}"
-        say item[:diff] if options.diff
+        interject " M #{item[:pp_type]}  #{highlight_chg(fmtr(item, options))}"
+        interject item[:diff] if options.diff
       end
 
       unless ret[:skipd].empty?
-        pretty_group_header(ret[:skipd], 'Items without a solution', 'without a solution', options.grouped)
-        ret[:skipd].each { |item| say " - #{item[:pp_type]}  #{highlight_del(fmtr(item))}" }
+        pretty_group_header(
+          ret[:skipd], 'Items without a solution', 'without a solution', options.grouped
+        )
+        ret[:skipd].each do |item|
+          interject " - #{item[:pp_type]}  #{highlight_del(fmtr(item, options))}"
+        end
       end
 
-      return unless options.showall
-      say 'Unchanged:' if options.grouped
-      ret[:unchg].each { |item| say "   #{item[:pp_type]}  #{fmtr(item)}" }
+      return unless options.show_all
+      interject 'Unchanged:' if options.grouped
+      ret[:unchg].each { |item| interject "   #{item[:pp_type]}  #{fmtr(item, options)}" }
     end
 
     def pretty_group_header(group, header_any, header_empty, grouped)
       return unless grouped
       if !group.empty?
-        say "#{header_any}:"
+        interject "#{header_any}:"
       else
-        say "Nothing #{header_empty}"
+        interject "Nothing #{header_empty}"
       end
     end
 

--- a/lib/MrMurano/commands/status.rb
+++ b/lib/MrMurano/commands/status.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.08 /coding: utf-8
+# Last Modified: 2017.08.09 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -86,14 +86,8 @@ Endpoints can be selected with a "#<method>#<path glob>" pattern.
 
     def fmtr(item, options)
       if item.key?(:local_path)
-        if !item[:local_path].to_s.start_with?('/dev/null/')
-          desc = item[:local_path].relative_path_from(Pathname.pwd).to_s
-          desc = "#{desc}:#{item[:line]}" if item.key?(:line) && item[:line] > 0
-        else
-          # MAYBE: Indicate that the item doesn't really exist locally?
-          #desc = "#{item[:synckey]} [empty]"
-          desc = item[:synckey]
-        end
+        desc = item[:local_path].relative_path_from(Pathname.pwd).to_s
+        desc = "#{desc}:#{item[:line]}" if item.key?(:line) && item[:line] > 0
       else
         desc = item[:synckey]
       end

--- a/lib/MrMurano/commands/sync.rb
+++ b/lib/MrMurano/commands/sync.rb
@@ -19,7 +19,7 @@ def syncdown_files(options, args=nil)
   args = [] if args.nil?
   num_synced = 0
   MrMurano::SyncRoot.instance.each_filtered(options) do |_name, _type, klass, desc|
-    MrMurano::Verbose.whirly_msg "Syncing #{desc}..."
+    MrMurano::Verbose.whirly_msg "Syncing #{Inflecto.pluralize(desc)}..."
     sol = klass.new
     num_synced += sol.syncdown(options, args)
   end
@@ -72,7 +72,7 @@ Sync project up into Murano.
 
     #MrMurano::Verbose.whirly_start "Syncing solutions..."
     MrMurano::SyncRoot.instance.each_filtered(options.__hash__) do |_name, _type, klass, desc|
-      MrMurano::Verbose.whirly_msg "Syncing #{desc}..."
+      MrMurano::Verbose.whirly_msg "Syncing #{Inflecto.pluralize(desc)}..."
       sol = klass.new
       sol.syncup(options, args)
     end

--- a/lib/MrMurano/commands/sync.rb
+++ b/lib/MrMurano/commands/sync.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.26 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -7,6 +7,7 @@
 
 require 'MrMurano/verbosing'
 require 'MrMurano/SyncRoot'
+require 'MrMurano/commands/status'
 
 def sync_add_options(c, locale)
   c.option '--[no-]delete', %(Don't delete things from #{locale})
@@ -32,13 +33,9 @@ command :syncdown do |c|
   c.description = %(
 Sync project down from Murano.
   ).strip
+
   c.option '--all', 'Sync everything'
-
-  # Load options to control which things to sync
-  MrMurano::SyncRoot.instance.each_option do |s, l, d|
-    c.option s, l, d
-  end
-
+  command_add_syncable_options(c)
   sync_add_options(c, 'local machine')
 
   c.example %(Make local be like what is on the server), %(murano syncdown --all)
@@ -47,6 +44,7 @@ Sync project down from Murano.
 
   c.action do |args, options|
     options.default delete: true, create: true, update: true
+    command_set_syncable_defaults(options)
 
     syncdown_files(options.__hash__, args)
   end
@@ -59,13 +57,9 @@ command :syncup do |c|
   c.description = %(
 Sync project up into Murano.
   ).strip
+
   c.option '--all', 'Sync everything'
-
-  # Load options to control which things to sync
-  MrMurano::SyncRoot.instance.each_option do |s, l, d|
-    c.option s, l, d
-  end
-
+  command_add_syncable_options(c)
   sync_add_options(c, 'server')
 
   c.example %(Deploy project to server), %(murano syncup --all)
@@ -74,6 +68,7 @@ Sync project up into Murano.
 
   c.action do |args, options|
     options.default delete: true, create: true, update: true
+    command_set_syncable_defaults(options)
 
     #MrMurano::Verbose.whirly_start "Syncing solutions..."
     MrMurano::SyncRoot.instance.each_filtered(options.__hash__) do |_name, _type, klass, desc|

--- a/lib/MrMurano/hash.rb
+++ b/lib/MrMurano/hash.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.19 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -55,5 +55,23 @@ def ordered_hash(dict)
     end
   end
   ohash
+end
+
+##
+# Take a hash or something (a Commander::Command::Options) and return a hash
+#
+# @param hsh [Hash, Commander::Command::Options] Thing we want to be a Hash
+# @return [Hash] an actual Hash with default value of false
+def elevate_hash(hsh)
+  # Commander::Command::Options stripped all of the methods from parent
+  # objects. I have not nice thoughts about that.
+  begin
+    hsh = hsh.__hash__
+  # rubocop:disable Lint/HandleExceptions: Do not suppress exceptions.
+  rescue NoMethodError
+    # swallow this.
+  end
+  # build a hash where the default is 'false' instead of 'nil'
+  Hash.new(false).merge(Hash.transform_keys_to_symbols(hsh))
 end
 

--- a/lib/MrMurano/http.rb
+++ b/lib/MrMurano/http.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.20 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -13,6 +13,7 @@ require 'uri'
 # 2017-06-07: [lb] getting "execution expired (Net::OpenTimeout)" on http.start.
 # Suggestions online say to load the pure-Ruby DNS implementation, resolv.rb.
 require 'resolv-replace'
+require 'MrMurano/progress'
 
 module MrMurano
   module Http
@@ -63,7 +64,7 @@ module MrMurano
           end
         end
         if $cfg.curlfile_f.nil?
-          puts a.join(' ')
+          MrMurano::Progress.whirly_interject { puts a.join(' ') }
         else
           $cfg.curlfile_f << a.join(' ') + "\n\n"
           $cfg.curlfile_f.flush

--- a/lib/MrMurano/http.rb
+++ b/lib/MrMurano/http.rb
@@ -64,7 +64,7 @@ module MrMurano
           end
         end
         if $cfg.curlfile_f.nil?
-          MrMurano::Progress.whirly_interject { puts a.join(' ') }
+          MrMurano::Progress.instance.whirly_interject { puts a.join(' ') }
         else
           $cfg.curlfile_f << a.join(' ') + "\n\n"
           $cfg.curlfile_f.flush

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -6,7 +6,7 @@
 #  vim:tw=0:ts=2:sw=2:et:ai
 
 module MrMurano
-  VERSION = '3.0.0.beta.4.1'
+  VERSION = '3.0.0-beta.4.2'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.03 /coding: utf-8
+# Last Modified: 2017.08.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -6,7 +6,16 @@
 #  vim:tw=0:ts=2:sw=2:et:ai
 
 module MrMurano
-  VERSION = '3.0.0-beta.4.2'
+  # NOTE: `rake build` (a task added by postmodern/rubygems-tasks)
+  #   replaces the dash in the version with 'rep.', e.g.,
+  #     '3.0.0-beta.4.2' changes '3.0.0.pre.beta.4.2'
+  #   The build task is from https://github.com/postmodern/rubygems-tasks
+  #   The 'dash' in a version is part of http://semver.org/
+  # 2017-08-07: We've been cutting GitHub releases for each beta.X,
+  #   but not for any beta.X.pre.Y or beta.X-Y
+  # NOTE: 3.0.0.beta.5.pre.4 < 3.0.0.beta.5
+  VERSION = '3.0.0.beta.5.pre.1'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end
+

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.07 /coding: utf-8
+# Last Modified: 2017.08.09 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -6,14 +6,26 @@
 #  vim:tw=0:ts=2:sw=2:et:ai
 
 module MrMurano
-  # NOTE: `rake build` (a task added by postmodern/rubygems-tasks)
-  #   replaces the dash in the version with 'rep.', e.g.,
-  #     '3.0.0-beta.4.2' changes '3.0.0.pre.beta.4.2'
-  #   The build task is from https://github.com/postmodern/rubygems-tasks
-  #   The 'dash' in a version is part of http://semver.org/
-  # 2017-08-07: We've been cutting GitHub releases for each beta.X,
-  #   but not for any beta.X.pre.Y or beta.X-Y
-  # NOTE: 3.0.0.beta.5.pre.4 < 3.0.0.beta.5
+  # USAGE: Use 'beta.' and 'pre.' to label beta releases and dev builds.
+  #   For example, the first beta for a 3.0.0 release would be:
+  #     3.0.0.beta.1
+  #   After the beta release, developers would want to use a pre-build:
+  #     3.0.0.beta.2.pre.1
+  #   And then the next beta release drops the 'pre'-postfix:
+  #     3.0.0.beta.2
+  #   And finally the general release drops the 'beta'-postfix:
+  #     3.0.0
+  #   This works because of how versions are ordered, e.g.,
+  #     3.0.0.beta.1 < 3.0.0.beta.2.pre.1 < 3.0.0.beta.2 < 3.0.0
+  #
+  #   Note that we cannot follow the Semantic Version guidelines
+  #   from http://semver.org/. The guidelines say to use a dash to
+  #   separate the pre-release version, and a plus to separate the
+  #   build metadata, e.g., '3.0.0-beta.2+1'. However, the `rake build`
+  #   task replaces a dash in the version with the text, 'pre.', e.g.,
+  #     '3.0.0-beta.2' is changed to '3.0.0.pre.beta.2'
+  #   which breaks our build (which expects the version to match herein).
+  #   So stick to using the '.pre.X' syntax, which ruby/gems knows.
   VERSION = '3.0.0.beta.5.pre.1'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'

--- a/spec/Solution-ServiceModules_spec.rb
+++ b/spec/Solution-ServiceModules_spec.rb
@@ -443,13 +443,13 @@ RSpec.describe MrMurano::Module do
 
     it "raises on alias without name" do
       expect {
-        @srv.mkname( MrMurano::Module::EventHandlerItem.new() )
+        @srv.mkname(MrMurano::Module::EventHandlerItem.new())
       }.to raise_error(NameError)
     end
 
     it "raises on name without name" do
       expect {
-        @srv.mkalias( MrMurano::Module::EventHandlerItem.new() )
+        @srv.mkalias(MrMurano::Module::EventHandlerItem.new())
       }.to raise_error(NameError)
     end
   end

--- a/spec/SyncRoot_spec.rb
+++ b/spec/SyncRoot_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.31 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -51,7 +51,7 @@ RSpec.describe MrMurano::SyncRoot do
     $project.load
 
     @options = {}
-    @options.define_singleton_method(:method_missing) do |mid,*args|
+    @options.define_singleton_method(:method_missing) do |mid, *args|
       if mid.to_s.match(/^(.+)=$/) then
         self[$1.to_sym] = args.first
       else
@@ -92,15 +92,18 @@ RSpec.describe MrMurano::SyncRoot do
   it "selects custom defaults when none" do
     $cfg['sync.bydefault'] = 'role'
     MrMurano::SyncRoot.instance.check_same(@options)
-    expect(@options).to eq({:role=>true})
+    expect(@options).to eq({role: true})
   end
 
   it "builds option params" do
-    ret=[]
+    ret = []
     MrMurano::SyncRoot.instance.each_option do |s, l, d|
       ret << [s, l, d]
     end
-    expect(ret).to eq([["-u", "--[no-]user", "describe user"], ["-r", "--[no-]role", "describe role"]])
+    expect(ret).to eq([
+      ["-u", "--[no-]user", "describe user"],
+      ["-r", "--[no-]role", "describe role"],
+    ])
   end
 end
 

--- a/spec/SyncRoot_spec.rb
+++ b/spec/SyncRoot_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.08 /coding: utf-8
+# Last Modified: 2017.08.09 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -34,6 +34,7 @@ RSpec.describe MrMurano::SyncRoot do
         end
       end
     end
+    MrMurano::SyncRoot.instance.add('user', User, 'U', true)
     if !defined?(Role)
       class Role
         def self.description
@@ -41,7 +42,6 @@ RSpec.describe MrMurano::SyncRoot do
         end
       end
     end
-    MrMurano::SyncRoot.instance.add('user', User, 'U', true)
     MrMurano::SyncRoot.instance.add('role', Role, 'R', false)
 
     # This must happen after all syncables have been added.
@@ -101,8 +101,8 @@ RSpec.describe MrMurano::SyncRoot do
       ret << [s, l, d]
     end
     expect(ret).to eq([
-      ["-u", "--[no-]user", "describe user"],
-      ["-r", "--[no-]role", "describe role"],
+      ["-U", "--[no-]user", "describe user"],
+      ["-R", "--[no-]role", "describe role"],
     ])
   end
 end

--- a/spec/SyncUpDown_spec.rb
+++ b/spec/SyncUpDown_spec.rb
@@ -298,17 +298,17 @@ RSpec.describe MrMurano::SyncUpDown do
           :unchg=>[
             have_attributes(
               {
-                :name=>'three.lua',
-                :synckey=>'three.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/three.lua'),
-              }),
-            have_attributes(
-              {
                 :name=>'four.lua',
                 :synckey=>'four.lua',
                 :synctype=>TSUD.description,
                 :local_path=>pathname_globs('**/four.lua'),
+              }),
+            have_attributes(
+              {
+                :name=>'three.lua',
+                :synckey=>'three.lua',
+                :synctype=>TSUD.description,
+                :local_path=>pathname_globs('**/three.lua'),
               }),
           ],
           :toadd=>[
@@ -344,17 +344,17 @@ RSpec.describe MrMurano::SyncUpDown do
           :tomod=>[
             have_attributes(
               {
-                :name=>'one.lua',
-                :synckey=>'one.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/one.lua'),
-              }),
-            have_attributes(
-              {
                 :name=>'two.lua',
                 :synckey=>'two.lua',
                 :synctype=>TSUD.description,
                 :local_path=>pathname_globs('**/two.lua'),
+              }),
+            have_attributes(
+              {
+                :name=>'one.lua',
+                :synckey=>'one.lua',
+                :synctype=>TSUD.description,
+                :local_path=>pathname_globs('**/one.lua'),
               }),
           ],
           :skipd=>[],
@@ -402,19 +402,19 @@ RSpec.describe MrMurano::SyncUpDown do
         expect(ret).to match({
           :unchg=>[
             have_attributes(
-              :name=>'three.lua',
-              :synckey=>'three.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/three.lua')
-            ),
-            have_attributes(
               :name=>'four.lua',
               :synckey=>'four.lua',
               :synctype=>TSUD.description,
               :selected=>true,
               :local_path=>pathname_globs('**/four.lua')
               ),
+            have_attributes(
+              :name=>'three.lua',
+              :synckey=>'three.lua',
+              :synctype=>TSUD.description,
+              :selected=>true,
+              :local_path=>pathname_globs('**/three.lua')
+            ),
           ],
           :toadd=>[
             have_attributes(
@@ -448,18 +448,18 @@ RSpec.describe MrMurano::SyncUpDown do
           ],
           :tomod=>[
             have_attributes(
-              :name=>'one.lua',
-              :synckey=>'one.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/one.lua')
-            ),
-            have_attributes(
               :name=>'two.lua',
               :synckey=>'two.lua',
               :synctype=>TSUD.description,
               :selected=>true,
               :local_path=>pathname_globs('**/two.lua')
+            ),
+            have_attributes(
+              :name=>'one.lua',
+              :synckey=>'one.lua',
+              :synctype=>TSUD.description,
+              :selected=>true,
+              :local_path=>pathname_globs('**/one.lua')
             ),
           ],
           :skipd=>[],
@@ -530,7 +530,11 @@ RSpec.describe MrMurano::SyncUpDown do
     it "nothing when same." do
       expect(@t).to receive(:fetch).and_yield(%{-- fake lua\nreturn 0\n})
       ret = @t.dodiff(
-        { name: 'one.lua', local_path: @scpt, updated_at: ITEM_UPDATED_AT},
+        {
+          name: 'one.lua',
+          local_path: @scpt,
+          updated_at: ITEM_UPDATED_AT,
+        },
         nil
       )
       if Gem.win_platform? then
@@ -543,7 +547,11 @@ RSpec.describe MrMurano::SyncUpDown do
     it "something when different." do
       expect(@t).to receive(:fetch).and_yield(%{-- fake lua\nreturn 2\n})
       ret = @t.dodiff(
-        {name: 'one.lua', local_path: @scpt, updated_at: ITEM_UPDATED_AT},
+        {
+          name: 'one.lua',
+          local_path: @scpt,
+          updated_at: ITEM_UPDATED_AT,
+        },
         nil
       )
       expect(ret).not_to eq('')
@@ -553,7 +561,12 @@ RSpec.describe MrMurano::SyncUpDown do
       script = %{-- fake lua\nreturn 2\n}
       expect(@t).to receive(:fetch).and_yield(script)
       ret = @t.dodiff(
-        {name: 'one.lua', local_path: @scpt, script: script, updated_at: ITEM_UPDATED_AT},
+        {
+          name: 'one.lua',
+          local_path: @scpt,
+          script: script,
+          updated_at: ITEM_UPDATED_AT,
+        },
         nil
       )
       if Gem.win_platform? then

--- a/spec/cmd_init_spec.rb
+++ b/spec/cmd_init_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.27 /coding: utf-8
+# Last Modified: 2017.08.03 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -315,15 +315,19 @@ RSpec.describe 'murano init', :cmd do
     end
     after(:example) do
       Dir.chdir(ENV['HOME']) do
-        out, err, status = Open3.capture3(capcmd('murano', 'solution', 'delete', @product_name))
-        expect(out).to eq('')
-        expect(err).to eq('')
-        expect(status.exitstatus).to eq(0)
+        if defined?(@product_name)
+          out, err, status = Open3.capture3(capcmd('murano', 'solution', 'delete', @product_name))
+          expect(out).to eq('')
+          expect(err).to eq('')
+          expect(status.exitstatus).to eq(0)
+        end
 
-        out, err, status = Open3.capture3(capcmd('murano', 'solution', 'delete', @applctn_name))
-        expect(out).to eq('')
-        expect(err).to eq('')
-        expect(status.exitstatus).to eq(0)
+        if defined?(@applctn_name)
+          out, err, status = Open3.capture3(capcmd('murano', 'solution', 'delete', @applctn_name))
+          expect(out).to eq('')
+          expect(err).to eq('')
+          expect(status.exitstatus).to eq(0)
+        end
       end
     end
 

--- a/spec/cmd_init_spec.rb
+++ b/spec/cmd_init_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.03 /coding: utf-8
+# Last Modified: 2017.08.09 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -109,16 +109,20 @@ RSpec.describe 'murano init', :cmd do
         "\n",
       ]
     end
+    #expecting += [
+    #  t.a_string_matching(%r{Adding item \w+_event\n}),
+    #  # Order not consistent...
+    #  #"Adding item tsdb_exportJob\n",
+    #  #"Adding item timer_timer\n",
+    #  #"Adding item user_account\n",
+    #  t.a_string_starting_with('Adding item '),
+    #  t.a_string_starting_with('Adding item '),
+    #  t.a_string_starting_with('Adding item '),
+    #  "Synced 4 items\n",
+    #  "\n",
+    #]
     expecting += [
-      t.a_string_matching(%r{Adding item \w+_event\n}),
-      # Order not consistent...
-      #"Adding item tsdb_exportJob\n",
-      #"Adding item timer_timer\n",
-      #"Adding item user_account\n",
-      t.a_string_starting_with('Adding item '),
-      t.a_string_starting_with('Adding item '),
-      t.a_string_starting_with('Adding item '),
-      "Synced 4 items\n",
+      "Items already synced\n",
       "\n",
     ]
     expecting += [

--- a/spec/cmd_syncdown_spec.rb
+++ b/spec/cmd_syncdown_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.31 /coding: utf-8
+# Last Modified: 2017.08.08 /coding: utf-8
 # frozen_string_literal: probably not yet
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -71,18 +71,19 @@ RSpec.describe 'murano syncdown', :cmd, :needs_password do
       out_lines = out.lines.map { |line| line.encode!('UTF-8', 'UTF-8') }
       expect(out_lines).to match_array([
         "Adding item table_util\n",
-        a_string_starting_with('Removing item '),
-        "Removing item tsdb_exportJob\n",
-        "Removing item user_account\n",
         "Updating item timer_timer\n",
-        "Adding item device2_event\n",
+        # E.g., "Updating item i4kl64nn86xk00000_event\n":
+        a_string_starting_with('Updating item '),
+        "Updating item tsdb_exportJob\n",
+        "Updating item user_account\n",
+        #"Adding item device2_event\n",
         "Adding item POST_/api/fire\n",
         "Adding item PUT_/api/fire/{code}\n",
         "Adding item DELETE_/api/fire/{code}\n",
         "Adding item GET_/api/onfire\n",
-        "Adding item /js/script.js\n",
         "Adding item /icon.png\n",
         "Adding item /\n",
+        "Adding item /js/script.js\n",
       ])
 
       #expect(err).to eq('')
@@ -97,7 +98,9 @@ RSpec.describe 'murano syncdown', :cmd, :needs_password do
       out_lines = out.lines.map { |line| line.encode!('UTF-8', 'UTF-8') }
       expect(out_lines).to match_array([
         "Adding item table_util\n",
-        "Adding item timer_timer\n",
+        # 2017-08-08: This says updating now because timer.timer is undeletable.
+        #"Adding item timer_timer\n",
+        "Updating item timer_timer\n",
         "Adding item POST_/api/fire\n",
         "Adding item DELETE_/api/fire/{code}\n",
         "Adding item PUT_/api/fire/{code}\n",

--- a/spec/cmd_syncup_spec.rb
+++ b/spec/cmd_syncup_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.03 /coding: utf-8
+# Last Modified: 2017.08.09 /coding: utf-8
 # frozen_string_literal: probably not yet
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -60,10 +60,9 @@ RSpec.describe 'murano syncup', :cmd, :needs_password do
 
     def verify_err_missing_location(err)
       elines = err.lines
-      # FIXME/2017-07-13: Why is MurCLI spitting out two skipping-missing
-      # messages that indicate the same path being skipped? Shouldn't it
-      # just complain about it once?
-      expect(elines).to satisfy { |v| elines.length == 2 }
+      # E.g.,
+      #   Skipping missing location ‘/tmp/d20170809-7670-z315jn/project/services’ (Application Events)
+      expect(elines).to satisfy { |v| elines.length == 1 }
       elines.each do |line|
         expect(line.encode!('UTF-8', 'UTF-8')).to start_with("\e[33mSkipping missing location ‘")
       end
@@ -74,12 +73,12 @@ RSpec.describe 'murano syncup', :cmd, :needs_password do
       outl = out.lines
       # The spec tests set --no-progress, so each sync action gets reported.
       expect(outl[0]).to eq("Adding item table_util\n")
-      expect(outl[1]).to start_with("Removing item ")
-      # 2017-07-27: Why is the order of these not consistent? File globbing?
-      #expect(outl[2]).to eq("Removing item tsdb_exportJob\n")
-      #expect(outl[3]).to eq("Removing item timer_timer\n")
-      #expect(outl[4]).to eq("Removing item user_account\n")
-      (2..4).each { |ln| expect(outl[ln]).to start_with("Removing item ") }
+      #expect(outl[1]).to eq("Updating item c3juj9vnmec000000_event\n")
+      # The order isn't always consistent, so just do start_with.
+      #expect(outl[2]).to eq("Updating item tsdb_exportJob\n")
+      #expect(outl[3]).to eq("Updating item timer_timer\n")
+      #expect(outl[4]).to eq("Updating item user_account\n")
+      (1..4).each { |ln| expect(outl[ln]).to start_with("Updating item ") }
       #expect(outl[5]).to eq("Adding item POST_/api/fire\n")
       #expect(outl[6]).to eq("Adding item PUT_/api/fire/{code}\n")
       #expect(outl[7]).to eq("Adding item DELETE_/api/fire/{code}\n")
@@ -93,8 +92,6 @@ RSpec.describe 'murano syncup', :cmd, :needs_password do
       #expect(outl[15]).to eq("Adding item humidity\n")
       (5..15).each { |ln| expect(outl[ln]).to start_with("Adding item ") }
       expect(outl[16]).to eq("Updating product resources\n")
-      # err is, e.g.,
-      # "\e[33mSkipping missing location ‘/tmp/d20170727-17706-1v7jjmf/project/services’ (Application Event Handlers)\e[0m\n\e[33mSkipping missing location ‘/tmp/d20170727-17706-1v7jjmf/project/services’ (Product Event Handlers)\e[0m\n"
       verify_err_missing_location(err)
       expect(status.exitstatus).to eq(0)
 

--- a/spec/fixtures/dumped_config
+++ b/spec/fixtures/dumped_config
@@ -32,7 +32,8 @@ ignoring = *_test.lua *_spec.lua .*
 [eventhandler]
 searchFor = *.lua */*.lua {../eventhandlers,../event_handler}/*.lua {../eventhandlers,../event_handler}/*/*.lua
 ignoring = *_test.lua *_spec.lua .*
-skiplist = websocket webservice device.service_call interface device2.event
+skiplist = device.service_call device2.event interface webservice websocket
+undeletable = *.event timer.timer tsdb.exportJob user.account
 
 [modules]
 searchFor = *.lua **/*.lua


### PR DESCRIPTION
- MUR-3762: Prohibit MurCLI from deleting events
  - New config setting indicates which events to never DELETE,
    but whose scripts to set to empty string instead.
    - See config setting: `eventhandler.undeletable`
  - Related:
    - MRMUR-131: Unexpected Event Handler behavior
    - MRMUR-142: Seed App setup deletes solution interface event handler [serviceconfig]

- MRMUR-144: Nested Lua support fixes
  - Do not resolve symlinks in paths when determining nested Lua path.
  - Use `::File::SEPARATOR` for Windows support.

- MRMUR-141: Semantic versioning
  - Use \`pre.X\` syntax to indicate builds in between releases,
    e.g., if the latest release is `3.0.0.beta.1`, then the
    latest build would be `3.0.0.beta.2.pre.1`, in preparation
    for the next release, `3.0.0.beta.2`.

Miscellany:

- On Syncup, get `:updated_at` value for item to avoid false positives
  in next status or diff command.
  - On Diff, if an item is determined not to be dirty, set its
    `:updated_at` to avoid it being thought dirty the next time.

- If `MURANO_PASSWORD` fails, or Solution ID from `MURANO_CONFIGFILE` not found,
  warn user, upon exiting, that an environment overrides passwords cache or
  local project config, respectively.

- Better error handling and reporting for invalid command line options.