### PR TITLE
Option to disable Nested Lua support [--no-nesting]

### DIFF
--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.18 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -209,15 +209,25 @@ module MrMurano
         user.account
       ].join(' '), :defaults)
 
+      # 2017-07-26: Nested Lua support: Change '*/*.lua' to '**/*.lua'.
+      #   There are similar changes made to the ProjectFile,
+      #   to modules.include and modules.exclude, which, if set,
+      #   override modules.searchFor and modules.ignoring, respectively.
+      # NOTE: ** finds files in subdirs in subdirs,
+      #     e.g., modules/subdir1/subdir2/<here>/and/<here>
+      #     otherwise, */*.lua just finds files modules/subdir1/<here>.
       set('modules.searchFor', %w[
         *.lua
         **/*.lua
       ].join(' '), :defaults)
+
       set('modules.ignoring', %w[
         *_test.lua
         *_spec.lua
         .*
       ].join(' '), :defaults)
+
+      set('modules.no-nesting', false, :defaults)
 
       if Gem.win_platform?
         set('diff.cmd', 'fc', :defaults)

--- a/lib/MrMurano/ProjectFile.rb
+++ b/lib/MrMurano/ProjectFile.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.07.25 /coding: utf-8
+# Last Modified: 2017.08.18 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -40,10 +40,10 @@ module MrMurano
       # @param obj [Hash] Data to load in
       def load(obj)
         members.reject { |key| [:legacy].include? key }.each do |key|
-          self[key] = obj[key] if obj.key? key
+          self[key] = obj[key] if obj.key?(key)
         end
         members.select { |k| %i[include exclude].include? k }.each do |key|
-          self[key] = [self[key]] unless self[key].is_a? Array
+          self[key] = [self[key]] unless self[key].nil? || self[key].is_a?(Array)
         end
       end
 

--- a/lib/MrMurano/commands/status.rb
+++ b/lib/MrMurano/commands/status.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.18 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -16,6 +16,14 @@ def cmd_option_syncable_pickers(cmd)
   end
   MrMurano::SyncRoot.instance.each_alias_opt do |long, desc|
     cmd.option long, Inflecto.pluralize(desc)
+  end
+
+  cmd.option(
+    '--[no-]nesting',
+    %(Disable support for arranging Lua modules hierarchically)
+  ) do |nestation|
+    # This is only called if user specifies switch.
+    $cfg['modules.no-nesting'] = !nestation
   end
 end
 

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.18 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -26,7 +26,7 @@ module MrMurano
   #     '3.0.0-beta.2' is changed to '3.0.0.pre.beta.2'
   #   which breaks our build (which expects the version to match herein).
   #   So stick to using the '.pre.X' syntax, which ruby/gems knows.
-  VERSION = '3.0.0.beta.6'
+  VERSION = '3.0.0.beta.7.pre.1'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -26,7 +26,7 @@ module MrMurano
   #     '3.0.0-beta.2' is changed to '3.0.0.pre.beta.2'
   #   which breaks our build (which expects the version to match herein).
   #   So stick to using the '.pre.X' syntax, which ruby/gems knows.
-  VERSION = '3.0.0.beta.7.pre.1'
+  VERSION = '3.0.0'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end

--- a/spec/fixtures/dumped_config
+++ b/spec/fixtures/dumped_config
@@ -38,6 +38,7 @@ undeletable = *.event timer.timer tsdb.exportJob user.account
 [modules]
 searchFor = *.lua **/*.lua
 ignoring = *_test.lua *_spec.lua .*
+no-nesting = false
 
 [diff]
 cmd = <%= Gem.win_platform? ? 'fc' : 'diff -u' %>


### PR DESCRIPTION
- Specify `--no-nesting` to disable Nested Lua support on status/diff/syncup/syncdown.

  - `--no-nesting` is the default behavior in Murano CLI v2.x as well as pre 3.0.0.beta.5.

- Allow user to only partially define sections in the ProjectFile.