### PR TITLE
Murano CLI v3.0.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # Copyright © 2016-2017 Exosite LLC.
 # License: MIT. See LICENSE.txt.
 #  vim:tw=0:ts=2:sw=2:et:ai
@@ -71,6 +71,14 @@ Metrics/PerceivedComplexity:
 Metrics/LineLength:
   Enabled: false
 
+# "Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load."
+# Rubocop suggests using safe_load.
+#   https://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-load
+#   https://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load
+# I think Psych.safe_load was added in Ruby 2.1, so we shouldn't use it. [lb]
+Security/YAMLLoad:
+  Enabled: false
+
 # "Use only ascii symbols in comments."
 Style/AsciiComments:
   Enabled: false
@@ -83,6 +91,12 @@ Style/Documentation:
 #  http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/ConditionalAssignment
 Style/ConditionalAssignment:
   EnforcedStyle: assign_inside_condition
+
+# "Use each_with_object instead of inject."
+Style/EachWithObject:
+  Exclude:
+    # Methods copy-pasted from a blog.
+    - 'lib/MrMurano/hash.rb'
 
 # "Put empty method definitions on a single line."
 # You can do, e.g.,
@@ -102,6 +116,7 @@ Style/FileName:
     - 'MuranoCLI.gemspec'
     - 'Rakefile'
     - 'lib/MrMurano.rb'
+    - 'lib/MrMurano/makePretty.rb'
     - 'lib/MrMurano/Account.rb'
     - 'lib/MrMurano/Business.rb'
     - 'lib/MrMurano/Config-Migrate.rb'
@@ -137,6 +152,23 @@ Style/GlobalVars:
 Style/NumericPredicate:
   Enabled: false
 
+# "Don't use parentheses around the condition of an elsif."
+# This is a matter of taste. Rubocop would have you do, e.g.,
+#   if something
+#      ...
+#   elsif another_thing ||
+#         something_else
+#     ...
+# But if you don't like lining up the condition like that, you
+# might want to try, e.g.,
+#   elsif (
+#     another_thing ||
+#     something_else
+#   )
+#     ...
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
 # "Provide an exception class and message as arguments to raise."
 Style/RaiseArgs:
   EnforcedStyle: compact
@@ -159,6 +191,22 @@ Style/RedundantParentheses:
 #  #EnforcedStyle: percent_r
 #  EnforcedStyle: slashes
 
+# "Use safe navigation (&.) instead of checking if an object exists before
+#  calling the method."
+#
+# - "The Safe Navigation Operator (&.) in Ruby"
+#    http://mitrev.net/ruby/2015/11/13/the-operator-in-ruby/
+#
+# The safe nav op was only added in Ruby 2.3.0, and we support 2.0.
+Style/SafeNavigation:
+  Enabled: false
+
+# "Do not use semicolons to terminate expressions."
+Style/Semicolon:
+  Exclude:
+    # Methods copy-pasted from a blog.
+    - 'lib/MrMurano/hash.rb'
+
 # "Avoid comma after the last parameter of a method call."
 # FIXME/2017-06-30: Is this okay?
 Style/TrailingCommaInArguments:
@@ -169,16 +217,6 @@ Style/TrailingCommaInLiteral:
   # Rather than disable, tweak for multiline lists, so Rubocop will
   # still tell you not to use trailing comma in single-line list.
   EnforcedStyleForMultiline: "consistent_comma"
-
-# "Use safe navigation (&.) instead of checking if an object exists before
-#  calling the method."
-#
-# - "The Safe Navigation Operator (&.) in Ruby"
-#    http://mitrev.net/ruby/2015/11/13/the-operator-in-ruby/
-#
-# The safe nav op was only added in Ruby 2.3.0, and we support 2.0.
-Style/SafeNavigation:
-  Enabled: false
 
 AllCops:
   Include:
@@ -203,20 +241,4 @@ AllCops:
     #
     # 2017-08-16: Ug.
     - 'lib/MrMurano/optparse.rb'
-    #
-    # FIXME/2017-07-25: Finish linting these files, and delete from this list.
-    # ✗ 2017-07-31: 943 offenses herein these 26 files.
-    # ✓ 2017-08-16: 420 offenses herein these 15 files.
-    - 'lib/MrMurano/Content.rb'
-    - 'lib/MrMurano/Mock.rb'
-    - 'lib/MrMurano/Setting.rb'
-    - 'lib/MrMurano/SubCmdGroupContext.rb'
-    - 'lib/MrMurano/Webservice-Endpoint.rb'
-    - 'lib/MrMurano/Webservice-File.rb'
-    - 'lib/MrMurano/hash.rb'
-    - 'lib/MrMurano/http.rb'
-    - 'lib/MrMurano/makePretty.rb'
-    - 'lib/MrMurano/commands/business.rb'
-    - 'lib/MrMurano/commands/cors.rb'
-    - 'lib/MrMurano/commands/settings.rb'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # Copyright © 2016-2017 Exosite LLC.
 # License: MIT. See LICENSE.txt.
 #  vim:tw=0:ts=2:sw=2:et:ai
@@ -135,6 +135,7 @@ Style/FileName:
     - 'lib/MrMurano/Solution.rb'
     - 'lib/MrMurano/SolutionId.rb'
     - 'lib/MrMurano/SubCmdGroupContext.rb'
+    - 'lib/MrMurano/SyncAllowed.rb'
     - 'lib/MrMurano/SyncRoot.rb'
     - 'lib/MrMurano/SyncUpDown.rb'
     - 'lib/MrMurano/Webservice-Cors.rb'

--- a/.trustme.vim
+++ b/.trustme.vim
@@ -13,12 +13,16 @@
 " since every time we call autocmd, the command is appended,
 " and this file gets sourced every switch to a corresponding
 " project buffer.
-augroup trustme
-  " Remove! all trustme autocommands.
-  autocmd! trustme
-  "autocmd BufWrite *.rb silent !touch TOUCH
-  "autocmd BufWrite <buffer> echom "trustme is hooked!"
-  " MEH/2017-08-02: This won't hook bin/murano.
-  autocmd BufWrite <buffer> silent !./.trustme.sh &
-augroup END
+"augroup trustme
+"  " Remove! all trustme autocommands.
+"  autocmd! trustme
+"  "autocmd BufWrite *.rb silent !touch TOUCH
+"  "autocmd BufWrite <buffer> echom "trustme is hooked!"
+"  " MEH/2017-08-02: This won't hook bin/murano.
+""  autocmd BufWrite <buffer> silent !./.trustme.sh &
+"  autocmd BufWritePost <buffer> silent !./.trustme.sh &
+"augroup END
+
+"echomsg 'Calling trustme.sh'
+silent !./.trustme.sh &
 

--- a/bin/murano
+++ b/bin/murano
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -42,22 +42,9 @@ program :description, %(
 # or
 #   VAR=$(murano command ...)
 # etc., then do not do progress.
-# NOTE: This only works on POSIX systems....
-begin
-  # For files, `readlink` returns, e.g.,
-  #   fu5rse4xdww2ke29
-  # For piped subshells, `readlink` returns, e.g.,
-  #   pipe:[973352]
-  # MAGIC_NUMBER: 1 is the processes's output file descriptor.
-  #link = File.readlink("/proc/#{$$}/fd/1")
-  link = File.readlink("/proc/#{$PROCESS_ID}/fd/1")
-  if link.start_with?('pipe:') && !ARGV.include?('--no-progress') && !ARGV.include?('--progress')
-    ARGV.push('--no-progress')
-  end
-# rubocop:disable Lint/HandleExceptions: "Do not suppress exceptions."
-# Seems like a dumb rule. [lb]
-rescue Errno::ENOENT
-  # Meh.
+# TEST/2017-08-23: Does this work on Windows?
+unless $stdout.tty?
+  ARGV.push('--no-progress')
 end
 
 default_command :help

--- a/bin/murano
+++ b/bin/murano
@@ -8,6 +8,7 @@
 
 require 'commander/import'
 require 'dotenv'
+require 'English'
 require 'highline'
 require 'pathname'
 #require 'pp'
@@ -36,14 +37,6 @@ program :description, %(
   Manage Applications and Products in Exosite's Murano
 ).strip
 
-# The Commander defaults to paged help.
-# The user can disable with --no-page, e.g.,
-#   alias murano='murano --no-page'
-if ARGV.include?('--no-page')
-  program :help_paging, false
-  ARGV.delete('--no-page')
-end
-
 # If being piped, e.g.,
 #   murano command ... | ...
 # or
@@ -56,10 +49,13 @@ begin
   # For piped subshells, `readlink` returns, e.g.,
   #   pipe:[973352]
   # MAGIC_NUMBER: 1 is the processes's output file descriptor.
-  link = File.readlink("/proc/#{$$}/fd/1")
+  #link = File.readlink("/proc/#{$$}/fd/1")
+  link = File.readlink("/proc/#{$PROCESS_ID}/fd/1")
   if link.start_with?('pipe:') && !ARGV.include?('--no-progress') && !ARGV.include?('--progress')
     ARGV.push('--no-progress')
   end
+# rubocop:disable Lint/HandleExceptions: "Do not suppress exceptions."
+# Seems like a dumb rule. [lb]
 rescue Errno::ENOENT
   # Meh.
 end
@@ -100,4 +96,18 @@ $cfg.validate_cmd
 # Look for a (legacy) Solutionfile.json.
 $project = MrMurano::ProjectFile.new
 $project.load
+
+# The Commander defaults to paged help.
+# The user can disable with --no-page, e.g.,
+#   alias murano='murano --no-page'
+# We define this here and not in globals.rb because
+#   `murano --help` does not cause globals.rb to be sourced.
+paging = nil
+paging = true if ARGV.include?('--page')
+paging = false if ARGV.include?('--no-page')
+unless paging.nil?
+  program :help_paging, paging
+  $cfg['tool.no-page'] = !paging
+end
+# else, commander defaults to paging.
 

--- a/bin/murano
+++ b/bin/murano
@@ -43,9 +43,7 @@ program :description, %(
 #   VAR=$(murano command ...)
 # etc., then do not do progress.
 # TEST/2017-08-23: Does this work on Windows?
-unless $stdout.tty?
-  ARGV.push('--no-progress')
-end
+ARGV.push('--no-progress') unless $stdout.tty?
 
 default_command :help
 

--- a/bin/murano
+++ b/bin/murano
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -42,6 +42,26 @@ program :description, %(
 if ARGV.include?('--no-page')
   program :help_paging, false
   ARGV.delete('--no-page')
+end
+
+# If being piped, e.g.,
+#   murano command ... | ...
+# or
+#   VAR=$(murano command ...)
+# etc., then do not do progress.
+# NOTE: This only works on POSIX systems....
+begin
+  # For files, `readlink` returns, e.g.,
+  #   fu5rse4xdww2ke29
+  # For piped subshells, `readlink` returns, e.g.,
+  #   pipe:[973352]
+  # MAGIC_NUMBER: 1 is the processes's output file descriptor.
+  link = File.readlink("/proc/#{$$}/fd/1")
+  if link.start_with?('pipe:') && !ARGV.include?('--no-progress') && !ARGV.include?('--progress')
+    ARGV.push('--no-progress')
+  end
+rescue Errno::ENOENT
+  # Meh.
 end
 
 default_command :help

--- a/docs/basic_example.rst
+++ b/docs/basic_example.rst
@@ -247,7 +247,7 @@ just grab a random UUID.
 
     $ SOME_ID=$(uuidgen)
 
-    $ murano device enable ${SOME_ID}
+    $ murano device enable ${SOME_ID} --expire 1
 
     $ murano device list
 

--- a/docs/completions/murano_completion-bash
+++ b/docs/completions/murano_completion-bash
@@ -14,6 +14,7 @@ __app_switches=(
     --no-page
     --no-plugins
     --no-progress
+    --no-ascii
     --verbose
     --help
     --version
@@ -78,6 +79,7 @@ function _murano () {
         diff
         domain
         find
+        gwe
         help
         init
         keystore
@@ -163,6 +165,9 @@ function _murano () {
         ;;
         (find)
           __murano-find "$cmd1" "$cmd2" "${used_switches[@]}"
+        ;;
+        (gwe)
+          __murano-gwe "$cmd1" "$cmd2" "${used_switches[@]}"
         ;;
         (help)
           __murano-help "$cmd1" "$cmd2" "${used_switches[@]}"
@@ -795,6 +800,7 @@ function __murano-content () {
     case $subcmd1 in
       (delete)
       more_switches=(
+        {--trace}
       )
       ;;
       (download)
@@ -1091,7 +1097,10 @@ function __murano-device () {
       enable
       httpurl
       list
+      lock
       read
+      revoke
+      unlock
       write
     )
   else
@@ -1118,9 +1127,21 @@ function __murano-device () {
         {--trace}
       )
       ;;
+      (lock)
+      more_switches=(
+      )
+      ;;
       (read)
       more_switches=(
         {--trace}
+      )
+      ;;
+      (revoke)
+      more_switches=(
+      )
+      ;;
+      (unlock)
+      more_switches=(
       )
       ;;
       (write)
@@ -1411,6 +1432,72 @@ function __murano-find () {
       (product)
       more_switches=(
         {--trace}
+      )
+      ;;
+    esac
+  fi
+
+  # Add unused application-wide flags.
+  local idx
+  for ((idx = 0; idx < ${#__app_switches[@]}; idx++)); do
+    local switch=${__app_switches[$idx]}
+    if ! contains_element "$switch" "${used_switches[@]}"; then
+      comp_list+=("$switch")
+    fi
+  done
+  # Add unused subcommand flags.
+  for ((idx = 0; idx < ${#more_switches[@]}; idx++)); do
+    local switch=${more_switches[$idx]}
+    comp_list+=("$switch")
+  done
+
+  # If there are only --flags, <TAB> will put the common prefix,
+  # "--", but maybe the user doesn't want to add a flag after all.
+  if [[ -z ${last} ]]; then
+    local flags_only=true
+    for ((idx = 0; idx < ${#comp_list[@]}; idx++)); do
+      local switch=${comp_list[$idx]}
+      if [[ ${switch} != --* ]]; then
+        flags_only=false
+        break
+      fi
+    done
+    if ${flags_only}; then
+      # Use two Unicode en spaces to prevent compgen from prefixing "--".
+      comp_list+=("	 ")
+    fi
+  fi
+
+  COMPREPLY=($(compgen -W '${comp_list[@]}' -- "${last}"))
+}
+
+# Completion for subcommand: "gwe".
+function __murano-gwe () {
+  local subcmd1="$1"
+  local subcmd2="$2"
+  #local subcmdn="$3"
+  local used_switches="${@:3}"
+  local last="${COMP_WORDS[COMP_CWORD]}"
+  local len=$(($COMP_CWORD - 1))
+
+  local -a more_switches
+
+  local -a comp_list
+
+  #>&2 echo -e "\nsubcmd1=$subcmd1 / subcmd2=$subcmd2 / last=$last / len=$len"
+  #>&2 echo "used_switches=$used_switches"
+  #>&2 echo "more_switches=$more_switches"
+
+  # NOTE: Not doing anything special for ${subcmd2}.
+  #       Are there sub-sub-commands we shoud list?
+  if [[ -z ${subcmd1} || ${len} -eq 1 ]]; then
+    comp_list=(
+      app
+    )
+  else
+    case $subcmd1 in
+      (app)
+      more_switches=(
       )
       ;;
     esac
@@ -2274,6 +2361,7 @@ function __murano-password () {
       ;;
       (delete)
       more_switches=(
+        {--trace}
       )
       ;;
       (list)

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -129,7 +129,7 @@ Or set your password with `murano password set <username>`.
         error 'Check to see if username and password are correct.'
         unless ENV['MURANO_PASSWORD'].to_s.empty?
           pwd_path = $cfg.file_at('passwords', :user)
-          warning "BEWARE: The password used was from MURANO_PASSWORD, not from #{pwd_path}"
+          warning "NOTE: MURANO_PASSWORD specifies the password; it was not read from #{pwd_path}"
         end
         @token = nil
       end

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -158,7 +158,7 @@ Or set your password with `murano password set <username>`.
           (
             match_bid.include?(biz[:bizid]) ||
             match_name.include?(biz[:name]) ||
-            match_termy.any? do |term|
+            match_fuzzy.any? do |term|
               biz[:name] =~ /#{Regexp.escape(term)}/i || biz[:bizid] =~ /#{Regexp.escape(term)}/i
             end
           )

--- a/lib/MrMurano/Business.rb
+++ b/lib/MrMurano/Business.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -119,7 +119,7 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
     end
 
     def pretty_name_and_id
-      "‘#{Rainbow(name).underline}’ <#{bid}>"
+      "#{fancy_ticks(Rainbow(name).underline)} <#{bid}>"
     end
 
     # ---------------------------------------------------------------------
@@ -247,7 +247,7 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
       elsif type == :product
         sol = MrMurano::Product.new(sid)
       else
-        #raise "Unexpected path: Unrecognized type ‘#{type}’"
+        #raise "Unexpected path: Unrecognized type #{fancy_ticks(type)}"
         sol = MrMurano::Solution.new(sid)
       end
       sol.biz = self
@@ -275,7 +275,7 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
           workit_response(response)
         else
           MrMurano::Verbose.error(
-            "Unable to create #{sol.type_name}: ‘#{sol.name}’"
+            "Unable to create #{sol.type_name}: #{fancy_ticks(sol.name)}"
           )
           ok = false
           if response.is_a?(Net::HTTPConflict)
@@ -329,12 +329,12 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
       #  if ret.count > 1
       #    warning("Found more than 1 matching solution: #{ret}")
       #  elsif ret.count.zero?
-      #    error("Unable to verify solution created for ‘#{sol.name}’: #{ret}")
+      #    error("Unable to verify solution created for #{fancy_ticks(sol.name)}: #{ret}")
       #    exit 3
       #  end
       #  sol.meta = ret.first
       #  if sol.sid.to_s.empty? then
-      #    error("New solution created for ‘#{sol.name}’ missing ID?: #{ret}")
+      #    error("New solution created for #{fancy_ticks(sol.name)} missing ID?: #{ret}")
       #    exit 3
       #  end
       #  sol.sid = sid

--- a/lib/MrMurano/Config-Migrate.rb
+++ b/lib/MrMurano/Config-Migrate.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -21,8 +21,6 @@ module MrMurano
       return unless solsecret.exist?
       # Is in JSON, which as a subset of YAML, so use YAML parser
       solsecret.open do |io|
-        # rubocop:disable Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load.
-        # MAYBE/2017-07-02: Switch to YAML.safe_load.
         ss = YAML.load(io)
 
         pff = $cfg.file_at('passwords', :user)

--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.18 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -335,6 +335,8 @@ module MrMurano
       @paths.each(&:load)
       # If user wants curl commands dumped to a file, open that file.
       init_curl_file
+      # If user doesn't want paging, disable it.
+      program :help_paging, !$cfg['tool.no-page'] unless $cfg['tool.no-page'].nil?
     end
 
     ## Load specified file into the config stack

--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -356,6 +356,7 @@ module MrMurano
 
       section, ikey = key.split('.')
       paths.each do |path|
+        next if path.data.nil?
         next unless path.data.has_section?(section)
         sec = path.data[section]
         return sec if ikey.nil?
@@ -437,8 +438,12 @@ module MrMurano
       end
 
       paths = @paths.select { |p| scope == p.kind }
-      raise "Unknown scope ‘#{scope}’" if paths.empty?
-      raise "Too many scopes ‘#{scope}’" if paths.length > 1
+      if paths.empty? || paths.length > 1
+        scope_q = fancy_ticks(scope)
+        raise "Unknown scope: #{scope_q}" if paths.empty?
+        paths_q = fancy_ticks(paths)
+        raise "Too many paths: #{paths_q} / scope: #{scope_q}" if paths.length > 1
+      end
 
       cfg = paths.first
       data = cfg.data
@@ -490,7 +495,8 @@ module MrMurano
 
         cfg_paths = @paths.select { |p| p.kind == scope }
 
-        msg = "Scope: ‘#{scope}’\n\n"
+        scope_q = fancy_ticks(scope)
+        msg = "Scope: #{scope_q}\n\n"
         locats += Rainbow(msg).bright.underline
 
         if !cfg_paths.empty?
@@ -500,9 +506,9 @@ module MrMurano
             path = "Path: #{cfg.path}\n"
           elsif %i[internal defaults].include? cfg.kind
             # cfg.path is nil.
-            path = "Path: ‘#{scope}’ config is not saved.\n"
+            path = "Path: #{scope_q} config is not saved.\n"
           else
-            path = "Path: ‘#{scope}’ config does not exist.\n"
+            path = "Path: #{scope_q} config does not exist.\n"
           end
           #locats += Rainbow(path).bright
           locats += path
@@ -537,11 +543,11 @@ module MrMurano
             locats += msg
           end
         else
-          msg = "No config found for ‘#{scope}’.\n"
+          msg = "No config found for #{scope_q}.\n"
           if scope != :specified
             locats += Rainbow(msg).red.bright
           else
-            locats += "Path: ‘#{scope}’ config does not exist.\n\n"
+            locats += "Path: #{scope_q} config does not exist.\n\n"
             locats += "Use --configfile to specify this config file.\n"
           end
         end

--- a/lib/MrMurano/Content.rb
+++ b/lib/MrMurano/Content.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -132,7 +132,7 @@ module MrMurano
           case response
           # rubocop:disable Lint/EmptyWhen
           # "Avoid when branches without a body."
-          # "I'm going to all this."
+          # "I'm going to allow this."
           when Net::HTTPSuccess
             # pass
           else

--- a/lib/MrMurano/Content.rb
+++ b/lib/MrMurano/Content.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -89,6 +89,8 @@ module MrMurano
         }
         params[:tags] = tags.to_json if !tags.nil? && tags.is_a?(Hash)
 
+        return unless upload_item_allowed(name)
+
         ret = get("/#{CGI.escape(name)}/upload?#{URI.encode_www_form(params)}")
         debug "POST instructions: #{ret}"
         raise "Method isn't POST!!!" unless ret.is_a?(Hash) && ret[:method] == 'POST'
@@ -140,6 +142,7 @@ module MrMurano
       # Remove content by name
       # @param name [String] Name of content to be deleted
       def remove(name)
+        return unless remove_item_allowed(name)
         delete("/#{CGI.escape(name)}")
       end
 
@@ -147,6 +150,7 @@ module MrMurano
       # @param name [String] Name of content to be downloaded
       # @param block [Block] Block to process data as it is downloaded
       def download(name, &block)
+        return unless download_item_allowed(name)
         # This is a two step process.
         # 1: Get the get instructions for S3.
         # 2: fetch from S3.

--- a/lib/MrMurano/Content.rb
+++ b/lib/MrMurano/Content.rb
@@ -15,6 +15,7 @@ require 'MrMurano/Config'
 require 'MrMurano/http'
 require 'MrMurano/verbosing'
 require 'MrMurano/SolutionId'
+require 'MrMurano/SyncAllowed'
 require 'MrMurano/SyncUpDown'
 
 module MrMurano
@@ -24,6 +25,7 @@ module MrMurano
       include Http
       include Verbose
       include SolutionId
+      include SyncAllowed
 
       def initialize
         @solntype = 'product.id'

--- a/lib/MrMurano/Content.rb
+++ b/lib/MrMurano/Content.rb
@@ -1,3 +1,10 @@
+# Last Modified: 2017.08.20 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
 require 'uri'
 require 'cgi'
 require 'net/http'
@@ -35,7 +42,7 @@ module MrMurano
       def endpoint(path='')
         super
         parts = ['https:/', $cfg['net.host'], 'api:1'] + @uriparts
-        s = parts.map{|v| v.to_s}.join('/')
+        s = parts.map(&:to_s).join('/')
         URI(s + path.to_s)
       end
 
@@ -73,16 +80,14 @@ module MrMurano
         # ?type=
         sha256 = Digest::SHA256.new
         sha256.file(local_path.to_s)
-        mime = MIME::Types.type_for(local_path.to_s)[0] || MIME::Types["application/octet-stream"][0]
+        mime = MIME::Types.type_for(local_path.to_s)[0] || MIME::Types['application/octet-stream'][0]
 
         params = {
-          :sha256 => sha256.hexdigest,
-          :expires_in => 30,
-          :type => mime,
+          sha256: sha256.hexdigest,
+          expires_in: 30,
+          type: mime,
         }
-        if not tags.nil? and tags.kind_of? Hash then
-          params[:tags] = tags.to_json
-        end
+        params[:tags] = tags.to_json if !tags.nil? && tags.is_a?(Hash)
 
         ret = get("/#{CGI.escape(name)}/upload?#{URI.encode_www_form(params)}")
         debug "POST instructions: #{ret}"
@@ -91,24 +96,24 @@ module MrMurano
 
         uri = URI(ret[:url])
         request = Net::HTTP::Post.new(uri)
-        file = HTTP::FormData::File.new(local_path.to_s, {:content_type=>mime})
-        form = HTTP::FormData.create(ret[:inputs].merge({ret[:field]=>file}))
+        file = HTTP::FormData::File.new(local_path.to_s, content_type: mime)
+        form = HTTP::FormData.create(ret[:inputs].merge(ret[:field] => file))
 
         request['User-Agent'] = "MrMurano/#{MrMurano::VERSION}"
         request.content_type = form.content_type
         request.content_length = form.content_length
         request.body = form.to_s
 
-        if $cfg['tool.curldebug'] then
+        if $cfg['tool.curldebug']
           a = []
-          a << %{curl -s}
-          a << %{-H 'User-Agent: #{request['User-Agent']}'}
-          a << %{-X #{request.method}}
-          a << %{'#{request.uri.to_s}'}
+          a << %(curl -s)
+          a << %(-H 'User-Agent: #{request['User-Agent']}')
+          a << %(-X #{request.method})
+          a << %('#{request.uri}')
           ret[:inputs].each_pair do |key, value|
-            a << %{-F '#{key}=#{value}'}
+            a << %(-F '#{key}=#{value}')
           end
-          a << %{-F #{ret[:field]}=@#{local_path.to_s}}
+          a << %(-F #{ret[:field]}=@#{local_path})
           if $cfg.curlfile_f.nil?
             puts a.join(' ')
           else
@@ -117,14 +122,17 @@ module MrMurano
           end
         end
 
-        unless $cfg['tool.dry'] then
-          Net::HTTP.start(uri.host, uri.port, {:use_ssl=>true}) do |ihttp|
-            response = ihttp.request(request)
-            case response
-            when Net::HTTPSuccess
-            else
-              showHttpError(request, response)
-            end
+        return if $cfg['tool.dry']
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |ihttp|
+          response = ihttp.request(request)
+          case response
+          # rubocop:disable Lint/EmptyWhen
+          # "Avoid when branches without a body."
+          # "I'm going to all this."
+          when Net::HTTPSuccess
+            # pass
+          else
+            showHttpError(request, response)
           end
         end
       end
@@ -150,12 +158,12 @@ module MrMurano
         request = Net::HTTP::Get.new(uri)
         request['User-Agent'] = "MrMurano/#{MrMurano::VERSION}"
 
-        if $cfg['tool.curldebug'] then
+        if $cfg['tool.curldebug']
           a = []
-          a << %{curl -s}
-          a << %{-H 'User-Agent: #{request['User-Agent']}'}
-          a << %{-X #{request.method}}
-          a << %{'#{request.uri.to_s}'}
+          a << %(curl -s)
+          a << %(-H 'User-Agent: #{request['User-Agent']}')
+          a << %(-X #{request.method})
+          a << %('#{request.uri}')
           if $cfg.curlfile_f.nil?
             puts a.join(' ')
           else
@@ -164,28 +172,25 @@ module MrMurano
           end
         end
 
-        unless $cfg['tool.dry'] then
-          Net::HTTP.start(uri.host, uri.port, {:use_ssl=>true}) do |ihttp|
-            ihttp.request(request) do |response|
-              case response
-              when Net::HTTPSuccess
-                if block_given? then
-                  response.read_body(&block)
-                else
-                  response.read_body do |chunk|
-                    $stdout.write chunk
-                  end
-                end
+        return if $cfg['tool.dry']
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |ihttp|
+          ihttp.request(request) do |response|
+            case response
+            when Net::HTTPSuccess
+              if block_given?
+                response.read_body(&block)
               else
-                showHttpError(request, response)
+                response.read_body do |chunk|
+                  $stdout.write chunk
+                end
               end
+            else
+              showHttpError(request, response)
             end
           end
         end
       end
-
     end
   end
 end
 
-#  vim: set ai et sw=2 ts=2 :

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -25,6 +25,7 @@ module MrMurano
       include Http
       include Verbose
       include SolutionId
+      include SyncAllowed
 
       def initialize
         @solntype = 'product.id'

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -393,8 +393,12 @@ module MrMurano
         props = { auth: {}, locked: false }
         # See: okami_api/api/swagger/swagger.yaml
         unless opts[:expire].nil?
-          raise ':expire must be a number' unless opts[:expire] =~ /^[0-9]+$/
-          props[:auth][:expire] = opts[:expire]
+          begin
+            props[:auth][:expire] = Integer(opts[:expire])
+          rescue ArgumentError
+            # Callers should prevent this, so ugly raise is okay.
+            raise ':expire option is not a valid number: #{fancy_ticks(opts[:expire])}'
+          end
         end
         unless opts[:type].nil?
           opts[:type] = opts[:type].to_sym

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -297,8 +297,6 @@ module MrMurano
         end
 
         here = {}
-        # rubocop:disable Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load.
-        # MAYBE/2017-07-02: Convert to safe_load.
         from.open { |io| here = YAML.load(io) }
         here = {} if here == false
 
@@ -412,7 +410,7 @@ module MrMurano
         file = HTTP::FormData::File.new(local.to_s, content_type: 'text/csv')
         form = HTTP::FormData.create(identities: file)
         req = Net::HTTP::Post.new(uri)
-        set_def_headers(req)
+        add_headers(req)
         req.content_type = form.content_type
         req.content_length = form.content_length
         req.body = form.to_s

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -524,10 +524,6 @@ module MrMurano
       def revoke(identifier)
         patch("/#{CGI.escape(identifier.to_s)}", auth: { expire: 0 })
       end
-
-      def authenticize(identifier, key, type)
-        patch("/#{CGI.escape(identifier.to_s)}", auth: { key: key, type: type })
-      end
     end
   end
 end

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -496,13 +496,33 @@ module MrMurano
       # @param values [Hash] Aliases and the values to write.
       def write(identifier, values)
         debug "Will Write: #{values}"
+        # EXPLAIN/2017-08-23: Why not escape the ID?
+        #   #{CGI.escape(identifier.to_s)}
         patch("/#{identifier}/state", values)
       end
 
       # Read the current state for a device
       # @param identifier [String] The identifier for the device to read.
       def read(identifier)
+        # EXPLAIN/2017-08-23: Why not escape the ID?
+        #   #{CGI.escape(identifier.to_s)}
         get("/#{identifier}/state")
+      end
+
+      def lock(identifier)
+        patch("/#{CGI.escape(identifier.to_s)}", locked: true)
+      end
+
+      def unlock(identifier)
+        patch("/#{CGI.escape(identifier.to_s)}", locked: false)
+      end
+
+      def revoke(identifier)
+        patch("/#{CGI.escape(identifier.to_s)}", auth: { expire: 0 })
+      end
+
+      def authenticize(identifier, key, type)
+        patch("/#{CGI.escape(identifier.to_s)}", auth: { key: key, type: type })
       end
     end
   end

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -155,10 +155,13 @@ module MrMurano
       end
 
       def remove(itemkey)
+        return unless remove_item_allowed(itemkey)
         @there.delete_if { |item| item[@itemkey] == itemkey }
       end
 
       def upload(_local, remote, _modify)
+        # Not calling, e.g., `return unless upload_item_allowed(local)`
+        #   See instead: syncup_after and syncdown_after/resources_write
         @there.delete_if { |item| item[@itemkey] == remote[@itemkey] }
         @there << remote.reject { |k, _v| %i[synckey synctype].include? k }
       end
@@ -192,6 +195,8 @@ module MrMurano
       end
 
       def download(_local, item)
+        # Not calling, e.g., `return unless download_item_allowed(item[@itemkey])`
+        #   See instead: syncup_after and syncdown_after/resources_write
         @here = locallist if @here.nil?
         # needs to append/merge with file
         @here.delete_if do |i|
@@ -218,7 +223,9 @@ module MrMurano
       end
 
       def removelocal(_local, item)
-        # needs to append/merge with file
+        # Not calling, e.g., `return unless removelocal_item_allowed(item[@itemkey])`
+        #   See instead: syncup_after and syncdown_after/resources_write
+        # Append/merge with file.
         key = @itemkey.to_sym
         @here.delete_if do |it|
           it[key] == item[key]
@@ -423,6 +430,7 @@ module MrMurano
       ## Delete a device
       # @param identifier [String] Who to delete.
       def remove(identifier)
+        return unless remove_item_allowed(identifier)
         delete("/#{CGI.escape(identifier.to_s)}")
       end
 

--- a/lib/MrMurano/Mock.rb
+++ b/lib/MrMurano/Mock.rb
@@ -1,3 +1,10 @@
+# Last Modified: 2017.08.20 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
 require 'erb'
 require 'securerandom'
 
@@ -9,55 +16,56 @@ module MrMurano
     end
 
     def show
-      file = Pathname.new(get_testpoint_path)
-      if file.exist? then
-        authorization = %{if request.headers["authorization"] == "}
+      file = Pathname.new(testpoint_path)
+      if file.exist?
+        authorization = %(if request.headers["authorization"] == ")
         file.open('rb') do |io|
           io.each_line do |line|
             auth_line = line.include?(authorization)
-            if auth_line then
+            if auth_line
               capture = /\=\= "(.*)"/.match(line)
               return capture.captures[0]
             end
           end
         end
       end
-      return false
+      false
     end
 
-    def get_mock_template
-      path = get_mock_template_path()
-      return ::File.read(path)
+    def mock_template
+      path = mock_template_path
+      ::File.read(path)
     end
 
-    def get_testpoint_path
+    def testpoint_path
       file_name = 'testpoint.post.lua'
-      path = %{#{$cfg['location.endpoints']}/#{file_name}}
-      return path
+      path = %(#{$cfg['location.endpoints']}/#{file_name})
+      path
     end
 
-    def get_mock_template_path
-      return ::File.join(::File.dirname(__FILE__), 'template', 'mock.erb')
+    def mock_template_path
+      ::File.join(::File.dirname(__FILE__), 'template', 'mock.erb')
     end
 
     def create_testpoint
       uuid = SecureRandom.uuid
-      template = ERB.new(get_mock_template)
+      template = ERB.new(mock_template)
       endpoint = template.result(binding)
 
-      Pathname.new(get_testpoint_path).open('wb') do |io|
+      Pathname.new(testpoint_path).open('wb') do |io|
         io << endpoint
       end
-      return uuid
+      uuid
     end
 
     def remove_testpoint
-      file = Pathname.new(get_testpoint_path)
-      if file.exist? then
+      file = Pathname.new(testpoint_path)
+      if file.exist?
         file.unlink
         return true
       end
-      return false
+      false
     end
   end
 end
+

--- a/lib/MrMurano/Passwords.rb
+++ b/lib/MrMurano/Passwords.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -81,6 +81,11 @@ module MrMurano
       return unless @data.is_a?(Hash)
       hd = @data[host]
       return unless !hd.nil? && hd.is_a?(Hash)
+      if $cfg['tool.dry']
+        MrMurano::Verbose.whirly_interject do
+          say(%(--dry: Not removing password for #{fancy_tick("#{user}@#{host}")}))
+        end
+      end
       @data[host].delete(user) if hd.key?(user)
     end
 

--- a/lib/MrMurano/Passwords.rb
+++ b/lib/MrMurano/Passwords.rb
@@ -85,6 +85,7 @@ module MrMurano
         MrMurano::Verbose.whirly_interject do
           say(%(--dry: Not removing password for #{fancy_ticks("#{user}@#{host}")}))
         end
+        return
       end
       @data[host].delete(user) if hd.key?(user)
     end

--- a/lib/MrMurano/Passwords.rb
+++ b/lib/MrMurano/Passwords.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -32,12 +32,6 @@ module MrMurano
       return unless @path.exist?
       @path.chmod(0o600)
       @path.open('rb') do |io|
-        # 2017-07-01: Rubocop suggests using safe_load.
-        #  https://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-load
-        #  https://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load
-        # 2017-07-05: Oh, I don't think safe_load exists in Ruby 2 or 2.2...
-        #@data = YAML.safe_load(io)
-        # rubocop:disable Security/YAMLLoad
         @data = YAML.load(io)
       end
     end

--- a/lib/MrMurano/Passwords.rb
+++ b/lib/MrMurano/Passwords.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -83,7 +83,7 @@ module MrMurano
       return unless !hd.nil? && hd.is_a?(Hash)
       if $cfg['tool.dry']
         MrMurano::Verbose.whirly_interject do
-          say(%(--dry: Not removing password for #{fancy_tick("#{user}@#{host}")}))
+          say(%(--dry: Not removing password for #{fancy_ticks("#{user}@#{host}")}))
         end
       end
       @data[host].delete(user) if hd.key?(user)

--- a/lib/MrMurano/ReCommander.rb
+++ b/lib/MrMurano/ReCommander.rb
@@ -165,8 +165,8 @@ module Commander
       # But if `murano command --help` is specified, don't let cmdr
       # handle it, otherwise it just shows the command description,
       # but not any of the subcommands (our SubCmdGroupContext code).
-      # Note: not checking help_opts here, which includes 'help, because
-      #   'help' might really be a command argument (like solution name).
+      # Note: not checking help_opts here, which includes 'help', because
+      #   'help' might really be a command argument (e.g., a solution name).
       do_help = (@args & %w[-h --help]).any? || active_command.name == 'help'
       if do_help
         # If there are options in addition to --help, then Commander
@@ -220,7 +220,7 @@ module Commander
             elsif switches.length == 1
               if switches.first[:args].any? { |opt| opt.start_with?('--') && opt.include?(' ') }
                 # There's a space in the --long setting, e.g., '--config KEY=VAL',
-                # so we know there's a argument following.
+                # so we know there's an argument following.
                 reject_next = true
               end
             end
@@ -254,7 +254,7 @@ module Commander
       # Though it sometimes work, like with:
       #   $ murano --help product device enable
       # but only because Commander shows help for the 'device' command.
-      # I.e., this doesn't work: murano product push --help
+      # I.e., this doesn't work: `murano product push --help`
       # So we'll just roll our own help for aliases!
       @args -= help_opts
       cli_cmd = MrMurano::Verbose.fancy_ticks(@purargs.join(' '))

--- a/lib/MrMurano/ReCommander.rb
+++ b/lib/MrMurano/ReCommander.rb
@@ -140,8 +140,9 @@ module Commander
       if err.message.start_with?('missing argument:')
         puts err.message
       else
+        err_msg = MrMurano::Verbose.fancy_ticks(err.message)
         MrMurano::Verbose.error(
-          "There was a problem interpreting the options: ‘#{err.message}’"
+          "There was a problem interpreting the options: #{err_msg}"
         )
       end
       exit 2
@@ -216,7 +217,7 @@ module Commander
       # I.e., this doesn't work: murano product push --help
       # So we'll just roll our own help for aliases!
       @args -= help_opts
-      cli_cmd = MrMurano::Verbose.fancy_tick(@purargs.join(' '))
+      cli_cmd = MrMurano::Verbose.fancy_ticks(@purargs.join(' '))
       if active_command.name == 'help'
         arg_cmd = @args.join(' ')
       else
@@ -227,7 +228,7 @@ module Commander
         matches = @aliases.keys.find_all { |key| key.start_with?('arg_cmd') }
         matches = @aliases.keys.find_all { |key| key.start_with?(@args[0]) } if matches.empty?
         unless matches.empty?
-          matches = matches.map { |match| MrMurano::Verbose.fancy_tick(match) }
+          matches = matches.map { |match| MrMurano::Verbose.fancy_ticks(match) }
           matches = matches.sort.join(', ')
           mur_msg = %(The #{cli_cmd} command includes: #{matches})
         end
@@ -237,7 +238,7 @@ module Commander
         mur_cmd += @aliases[arg_cmd] unless @aliases[arg_cmd].empty?
         mur_cmd = mur_cmd.join(' ')
         #mur_cmd = active_command.name if mur_cmd.empty?
-        mur_cmd = MrMurano::Verbose.fancy_tick(mur_cmd)
+        mur_cmd = MrMurano::Verbose.fancy_ticks(mur_cmd)
         mur_msg = %(The #{cli_cmd} command is really: #{mur_cmd})
       end
       return if mur_msg.empty?

--- a/lib/MrMurano/Solution-ServiceConfig.rb
+++ b/lib/MrMurano/Solution-ServiceConfig.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -70,6 +70,7 @@ module MrMurano
     end
 
     def remove(id)
+      return unless remove_item_allowed(id)
       delete("/#{id}")
     end
 

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.21 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -54,6 +54,7 @@ module MrMurano
 
     # ??? remove
     def remove(name)
+      return unless remove_item_allowed(name)
       delete('/' + name)
     end
 
@@ -79,10 +80,18 @@ module MrMurano
         name: name,
       )
       debug "f: #{localpath} >> #{pst.reject { |k, _| k == :script }.to_json}"
+      therealias = mkalias(thereitem)
+      upload_script(therealias, name, localpath, pst)
+    end
+
+    def upload_script(therealias, name, localpath, pst)
       # Try PUT. If 404, then POST.
       # I.e., PUT if not exists, else POST to create.
       updated_at = nil
-      put('/' + mkalias(thereitem), pst) do |request, http|
+
+      return unless upload_item_allowed(therealias)
+
+      put('/' + therealias, pst) do |request, http|
         response = http.request(request)
         isj, jsn = isJSON(response.body)
         # ORDER: An HTTPNoContent is also a HTTPSuccess, so the latter comes first.

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.18 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -181,8 +181,6 @@ module MrMurano
       cache_file = $cfg.file_at(cache_file_name)
       if cache_file.file?
         cache_file.open('r+') do |io|
-          # FIXME/2017-07-02: "Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load."
-          # rubocop:disable Security/YAMLLoad
           cache = YAML.load(io)
           cache = {} unless cache
           io.rewind
@@ -205,7 +203,6 @@ module MrMurano
       return nil unless cache_file.file?
       ret = nil
       cache_file.open('r') do |io|
-        # FIXME/2017-07-02: "Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load."
         cache = YAML.load(io)
         return nil unless cache
         if cache.key?(local_path.to_s)

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -599,7 +599,7 @@ module MrMurano
 
     def config_vars_translate(script, codec)
       new_script = ''
-      # Replace the service with a {{config.value}} if appropriate.
+      # Replace the service with a {config.variable} if appropriate.
       script.lines.each do |line|
         # @match_header finds a service and an event string, e.g., "--EVENT svc evt\n"
         md = @match_header.match(line)
@@ -618,7 +618,7 @@ module MrMurano
     def decode_config_var(term)
       decoded = term
       config_var = nil
-      # Try to match svc against a {config.value}.
+      # Try to match svc against a {config.variable}.
       mat = /^\{([^\.}]+)\.([^\.}]+)\}$/.match(term)
       unless mat.nil?
         # User specified a config value, e.g., "--#EVENT {product.id} event".
@@ -640,7 +640,7 @@ module MrMurano
       config_var = nil
       # MEH/2017-08-22: For now, only matching against one config var.
       #   Maybe in the future we'd want to examine all the config vars?
-      # MAGIC_STRING: {config.value} substitution.
+      # MAGIC_STRING: {config.variable} substitution.
       if term == $cfg['product.id']
         encoded = '{product.id}'
         config_var = 'product.id'

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -315,14 +315,14 @@ module MrMurano
       root = root.expand_path
       if path.basename.sub(/\.lua$/i, '').to_s.include?('.')
         warning(
-          "WARNING: Do not use periods in filenames. Rename: ‘#{path.basename}’"
+          "WARNING: Do not use periods in filenames. Rename: #{fancy_ticks(path.basename)}"
         )
       end
       path.dirname.ascend do |ancestor|
         break if ancestor == root
         if ancestor.basename.to_s.include?('.')
           warning(
-            "WARNING: Do not use periods in directory names. Rename: ‘#{ancestor.basename}’"
+            "WARNING: Do not use periods in directory names. Rename: #{fancy_ticks(ancestor.basename)}"
           )
         end
       end
@@ -625,7 +625,7 @@ module MrMurano
         config_var = "#{mat[1]}.#{mat[2]}"
         decoded = $cfg[config_var]
         if decoded.nil?
-          warning "Config value not found for variable: ‘#{term}’"
+          warning "Config value not found for variable: #{fancy_ticks(term)}"
           # The platform should complain about file not found,
           # and we'll process everything else.
           decoded = term

--- a/lib/MrMurano/Solution-Users.rb
+++ b/lib/MrMurano/Solution-Users.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -59,9 +59,6 @@ module MrMurano
       # for now, we'll read, modify, write
       here = []
       if local.exist?
-        # FIXME/2017-07-18: Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load.
-        #   Disabling [rubo]cop for now.
-        # rubocop:disable Security/YAMLLoad
         local.open('rb') { |io| here = YAML.load(io) }
         here = [] if here == false
       end
@@ -79,7 +76,6 @@ module MrMurano
       # for now, we'll read, modify, write
       here = []
       if local.exist?
-        # FIXME/2017-07-18: Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load.
         local.open('rb') { |io| here = YAML.load(io) }
         here = [] if here == false
       end
@@ -109,7 +105,6 @@ module MrMurano
 
       # MAYBE/2017-07-03: Do we care if there are duplicate keys in the yaml? See dup_count.
       here = []
-      # FIXME/2017-07-18: Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load.
       from.open { |io| here = YAML.load(io) }
       here = [] if here == false
 

--- a/lib/MrMurano/Solution.rb
+++ b/lib/MrMurano/Solution.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.21 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -127,6 +127,8 @@ module MrMurano
       #     the results.
       #path = path || '?select=id,service'
       matches = list(path)
+      # 2017-08-21: The only caller so far is the link command,
+      #   which passes the Solution ID as svc_name.
       matches.select { |match| match[:service] == svc_name }
     end
 

--- a/lib/MrMurano/Solution.rb
+++ b/lib/MrMurano/Solution.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.21 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -96,7 +96,7 @@ module MrMurano
             #query.push ['limit', 20]
             query.push ['offset', total - remaining]
           elsif remaining != 0
-            warning "Unexpected: negative remaining: ‘#{total}’"
+            warning "Unexpected: negative remaining: #{fancy_ticks(total)}"
             remaining = 0
           end
           if aggregate.nil?
@@ -242,23 +242,35 @@ module MrMurano
         end
       end
       unless @sid.to_s.empty? || sid.to_s == @sid.to_s
-        warning "#{type_name} ID mismatch. Server says ‘#{sid}’, but config says ‘#{@sid}’."
+        warning(
+          "#{type_name} ID mismatch. Server says #{fancy_ticks(sid)}, " \
+          "but config says #{fancy_ticks(@sid)}."
+        )
       end
       self.sid = sid
       # Verify/set the name.
       unless @name.to_s.empty? || @meta[:name].to_s == @name.to_s
-        warning "Name mismatch. Server says ‘#{@meta[:name]}’, but config says ‘#{@name}’."
+        warning(
+          "Name mismatch. Server says #{fancy_ticks(@meta[:name])}, " \
+          "but config says #{fancy_ticks(@name)}."
+        )
       end
       if !@meta[:name].to_s.empty?
         set_name(@meta[:name])
         unless @valid_name || type == :solution
-          warning "Unexpected: Server returned invalid name: ‘#{@meta[:name]}’"
+          warning(
+            "Unexpected: Server returned invalid name: #{fancy_ticks(@meta[:name])}"
+          )
         end
       elsif @meta[:domain]
         # This could be a pre-ADC/pre-Murano business.
-        warning "Unexpected: Server returned no name for domain: ‘#{@meta[:domain]}’"
+        warning(
+          "Unexpected: Server returned no name for domain: #{fancy_ticks(@meta[:domain])}"
+        )
       else
-        warning "Unexpected: Server returned no name for solution: ‘#{@meta}’"
+        warning(
+          "Unexpected: Server returned no name for solution: #{fancy_ticks(@meta)}"
+        )
       end
     end
 
@@ -324,7 +336,7 @@ module MrMurano
       if @name.to_s.empty?
         ''
       else
-        "‘#{@name}’"
+        fancy_ticks(@name)
       end
     end
 

--- a/lib/MrMurano/SolutionId.rb
+++ b/lib/MrMurano/SolutionId.rb
@@ -5,6 +5,8 @@
 # License: MIT. See LICENSE.txt.
 #  vim:tw=0:ts=2:sw=2:et:ai
 
+require 'MrMurano/verbosing'
+
 module MrMurano
   module SolutionId
     INVALID_SID = '-1'
@@ -69,7 +71,7 @@ module MrMurano
     def endpoint(_path='')
       # This is hopefully just a DEV error, and not something user will ever see!
       return unless @uriparts[@uriparts_sidex] == INVALID_SID
-      error("Solution ID missing! Invalid ‘#{@solntype}’")
+      error("Solution ID missing! Invalid #{MrMurano::Verbose.fancy_ticks(@solntype)}")
       exit 2
     end
   end

--- a/lib/MrMurano/SolutionId.rb
+++ b/lib/MrMurano/SolutionId.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -8,7 +8,9 @@
 module MrMurano
   module SolutionId
     INVALID_SID = '-1'
-    UNEXPECTED_TYPE_OR_ERROR_MSG = 'Unexpected result type or error: assuming empty instead'
+    UNEXPECTED_TYPE_OR_ERROR_MSG = (
+      'Unexpected result type or error: assuming empty instead'
+    )
 
     attr_reader :sid
     attr_reader :valid_sid
@@ -41,7 +43,9 @@ module MrMurano
 
     def sid=(sid)
       sid = INVALID_SID if sid.nil? || !sid.is_a?(String) || sid.empty?
-      @valid_sid = false if sid.to_s.empty? || sid == INVALID_SID || (defined?(@sid) && sid != @sid)
+      if sid.to_s.empty? || sid == INVALID_SID || (defined?(@sid) && sid != @sid)
+        @valid_sid = false
+      end
       @sid = sid
       # MAGIC_NUMBER: The 2nd element is the solution ID, e.g., solution/<sid>/...
       raise "Unexpected @uriparts_sidex #{@uriparts_sidex}" unless @uriparts_sidex == 1

--- a/lib/MrMurano/SubCmdGroupContext.rb
+++ b/lib/MrMurano/SubCmdGroupContext.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.21 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -31,7 +31,7 @@ module MrMurano
         @description
       when :help
         nil
-      # rubucop/disable Style/EmptyElse: "Redundant else-clause."
+      # rubocop:disable Style/EmptyElse: "Redundant else-clause."
       # Rubocop seems incorrect about this one.
       else
         nil

--- a/lib/MrMurano/SubCmdGroupContext.rb
+++ b/lib/MrMurano/SubCmdGroupContext.rb
@@ -1,16 +1,23 @@
+# Last Modified: 2017.08.20 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
 
 module MrMurano
   class SubCmdGroupHelp
-    attr :name, :description
+    attr_reader :description
+    attr_reader :name
 
     def initialize(command)
       @name = command.syntax.to_s
       @description = command.description.to_s
       @runner = ::Commander::Runner.instance
       prefix = /^#{command.name.to_s} /
-      cmds = @runner.instance_variable_get(:@commands).select{|n,_| n.to_s =~ prefix}
+      cmds = @runner.instance_variable_get(:@commands).select { |n, _| n.to_s =~ prefix }
       @commands = cmds
-      als = @runner.instance_variable_get(:@aliases).select{|n,_| n.to_s =~ prefix}
+      als = @runner.instance_variable_get(:@aliases).select { |n, _| n.to_s =~ prefix }
       @aliases = als
 
       @options = {}
@@ -24,6 +31,8 @@ module MrMurano
         @description
       when :help
         nil
+      # rubucop/disable Style/EmptyElse: "Redundant else-clause."
+      # Rubocop seems incorrect about this one.
       else
         nil
       end
@@ -37,6 +46,8 @@ module MrMurano
       @commands[name.to_s]
     end
 
+    # rubocop:disable Style/AccessorMethodName
+    # "Do not prefix reader method names with get_."
     def get_help
       hf = @runner.program(:help_formatter).new(self)
       pc = Commander::HelpFormatter::ProgramContext.new(self).get_binding
@@ -45,5 +56,3 @@ module MrMurano
   end
 end
 
-
-#  vim: set ai et sw=2 ts=2 :

--- a/lib/MrMurano/SyncAllowed.rb
+++ b/lib/MrMurano/SyncAllowed.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -14,7 +14,7 @@ module MrMurano
     def sync_item_allowed(actioning, item_name)
       if $cfg['tool.dry']
         MrMurano::Verbose.whirly_interject do
-          say("--dry: Not #{actioning} item: #{fancy_tick(item_name)}")
+          say("--dry: Not #{actioning} item: #{fancy_ticks(item_name)}")
         end
         false
       else

--- a/lib/MrMurano/SyncAllowed.rb
+++ b/lib/MrMurano/SyncAllowed.rb
@@ -1,0 +1,42 @@
+# Last Modified: 2017.08.22 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
+#require 'MrMurano/progress'
+#require 'MrMurano/verbosing'
+#require 'MrMurano/hash'
+
+module MrMurano
+  module SyncAllowed
+    def sync_item_allowed(actioning, item_name)
+      if $cfg['tool.dry']
+        MrMurano::Verbose.whirly_interject do
+          say("--dry: Not #{actioning} item: #{fancy_tick(item_name)}")
+        end
+        false
+      else
+        true
+      end
+    end
+
+    def remove_item_allowed(id)
+      sync_item_allowed('removing', id)
+    end
+
+    def upload_item_allowed(id)
+      sync_item_allowed('uploading', id)
+    end
+
+    def download_item_allowed(id)
+      sync_item_allowed('downloading', id)
+    end
+
+    def removelocal_item_allowed(id)
+      sync_item_allowed('removing-local', id)
+    end
+  end
+end
+

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -490,8 +490,10 @@ module MrMurano
             # This sets the alias for the output, so duplicates look unique.
             item[@itemkey.to_sym] = uniq_synckey
             items[uniq_synckey] = item
-            msg = "Duplicate definition found for ‘#{skey}’"
-            msg += " for ‘#{self.class.description}’" if self.class.description.to_s != ''
+            msg = "Duplicate definition found for #{fancy_ticks(skey)}"
+            if self.class.description.to_s != ''
+              msg += " for #{fancy_ticks(self.class.description)}"
+            end
             warning(msg)
             warning(" #{item.local_path}")
           else
@@ -504,9 +506,10 @@ module MrMurano
           # MEH/2017-07-31: This message is a little misleading on syncdown,
           #   e.g., in rspec ./spec/cmd_syncdown_spec.rb, one test blows away
           #   local directories and does a syncdown, and on stderr you'll see
-          #     Skipping missing location ‘/tmp/d20170731-3150-1f50uj4/project/specs/resources.yaml’ (Resources)
+          #     Skipping missing location
+          #      ‘/tmp/d20170731-3150-1f50uj4/project/specs/resources.yaml’ (Resources)
           #   but then later in the syncdown, that directory and file gets created.
-          msg = "Skipping missing location ‘#{location}’"
+          msg = "Skipping missing location #{fancy_ticks(location)}"
           unless self.class.description.to_s.empty?
             msg += " (#{Inflecto.pluralize(self.class.description)})"
           end

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.21 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -49,8 +49,6 @@ module MrMurano
       attr_accessor :synckey
       # @return [String] The syncable type.
       attr_accessor :synctype
-      # @return [String] For device2, the event type.
-      attr_accessor :type
       # @return [String] The updated_at time from the server is used to detect changes.
       attr_accessor :updated_at
       # @return [Integer] Positive if multiple conflicting files found for same item.

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -293,10 +293,10 @@ module MrMurano
     # @param local [Pathname] Full path of where to download to
     # @param item [Item] The item to download
     def download(local, item)
-#      if item[:bundled]
-#        warning "Not downloading into bundled item #{synckey(item)}"
-#        return
-#      end
+      #if item[:bundled]
+      #  warning "Not downloading into bundled item #{synckey(item)}"
+      #  return
+      #end
       id = item[@itemkey.to_sym]
       if id.nil?
         debug "!!! Missing '#{@itemkey}', using :id instead!"

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.18 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -605,7 +605,9 @@ module MrMurano
         pattern = pattern.gsub(%r{^\*\*\/}, '')
       end
 
-      ::File.fnmatch(pattern, path)
+      ignore = ::File.fnmatch(pattern, path)
+      debug "Excluded #{path}" if ignore
+      ignore
     end
 
     #######################################################################

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -18,6 +18,7 @@ require 'MrMurano/verbosing'
 require 'MrMurano/hash'
 #require 'MrMurano/Config'
 #require 'MrMurano/ProjectFile'
+require 'MrMurano/SyncAllowed'
 ##require 'MrMurano/SyncRoot'
 
 module MrMurano
@@ -27,6 +28,8 @@ module MrMurano
   # pulling those things.
   #
   module SyncUpDown
+    include SyncAllowed
+
     # This is one item that can be synced.
     class Item
       # @return [String] The name of this item.
@@ -628,33 +631,6 @@ module MrMurano
       script
     end
 
-    def sync_item_allowed(actioning, item_name)
-      if $cfg['tool.dry']
-        MrMurano::Verbose.whirly_interject do
-          say("--dry: Not #{actioning} item: #{fancy_tick(item_name)}")
-        end
-        false
-      else
-        true
-      end
-    end
-
-    def remove_item_allowed(id)
-      sync_item_allowed('removing', id)
-    end
-
-    def upload_item_allowed(id)
-      sync_item_allowed('uploading', id)
-    end
-
-    def download_item_allowed(id)
-      sync_item_allowed('downloading', id)
-    end
-
-    def removelocal_item_allowed(id)
-      sync_item_allowed('removing-local', id)
-    end
-
     #######################################################################
     # Methods that provide the core status/syncup/syncdown
 
@@ -1044,7 +1020,7 @@ module MrMurano
 
       (localbox.keys & therebox.keys).each do |key|
         # Skip this item if it's got duplicate conflicts.
-        next if localbox[key].dup_count == 0
+        next if !localbox[key].is_a?(Hash) && localbox[key].dup_count == 0
         # Want 'local' to override 'there' except for itemkey.
         if options[:asdown]
           mrg = therebox[key].reject { |k, _v| k == @itemkey.to_sym }

--- a/lib/MrMurano/Webservice-Cors.rb
+++ b/lib/MrMurano/Webservice-Cors.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -59,10 +59,16 @@ module MrMurano
         if !file.nil?
           data = YAML.load_file(file)
         else
-          data = $project['routes.cors']
+          file = $project['routes.cors']
           # If it is just a string, then is a file to load.
-          data = YAML.load_file(data) if data.is_a? String
+          if file.is_a? String
+            data = YAML.load_file(file)
+          else
+            data = file
+            file = %(ProjectFile['routes.cors'])
+          end
         end
+        return unless upload_item_allowed(file)
         put('', data)
       end
     end

--- a/lib/MrMurano/Webservice-Endpoint.rb
+++ b/lib/MrMurano/Webservice-Endpoint.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -118,6 +118,7 @@ module MrMurano
         remote = remote.to_h.select { |k, _v| limitkeys.include? k }
         #      post('', remote)
         if remote.is_a? @itemkey
+          return unless upload_item_allowed(remote[@itemkey])
           put('/' + remote[@itemkey], remote) do |request, http|
             response = http.request(request)
             case response
@@ -133,6 +134,8 @@ module MrMurano
           end
         else
           verbose "\tNo itemkey, creating"
+          #return unless upload_item_allowed(remote)
+          return unless upload_item_allowed(local)
           post('', remote)
         end
       end
@@ -140,6 +143,7 @@ module MrMurano
       ##
       # Delete an endpoint
       def remove(id)
+        return unless remove_item_allowed(id)
         delete('/' + id.to_s)
       end
 

--- a/lib/MrMurano/Webservice-Endpoint.rb
+++ b/lib/MrMurano/Webservice-Endpoint.rb
@@ -116,8 +116,7 @@ module MrMurano
         end
         limitkeys = [:method, :path, :script, :content_type, @itemkey]
         remote = remote.to_h.select { |k, _v| limitkeys.include? k }
-        #      post('', remote)
-        if remote.is_a? @itemkey
+        if remote.key? @itemkey
           return unless upload_item_allowed(remote[@itemkey])
           put('/' + remote[@itemkey], remote) do |request, http|
             response = http.request(request)

--- a/lib/MrMurano/Webservice-Endpoint.rb
+++ b/lib/MrMurano/Webservice-Endpoint.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -16,7 +16,6 @@ module MrMurano
   # …/endpoint
   module Webservice
     class Endpoint < WebserviceBase
-
       # Route Specific details on an Item
       class RouteItem < Item
         # @return [String] HTTP method for this endpoint
@@ -49,7 +48,7 @@ module MrMurano
         ret = get
         return [] unless ret.is_a?(Array)
         ret.map do |item|
-          if item[:content_type].to_s.empty? then
+          if item[:content_type].to_s.empty?
             item[:content_type] = 'application/json'
           end
           # XXX should this update the script header?
@@ -69,9 +68,9 @@ module MrMurano
 
         ret[:content_type] = 'application/json' if ret[:content_type].empty?
 
-        script = ret[:script].lines.map{|l|l.chomp}
+        script = ret[:script].lines.map(&:chomp)
 
-        aheader = (script.first or "")
+        aheader = (script.first || '')
 
         rh = ['--#ENDPOINT', ret[:method].upcase, ret[:path]]
         rh << ret[:content_type] if ret[:content_type] != 'application/json'
@@ -81,19 +80,21 @@ module MrMurano
         # If header is wrong, replace it.
 
         md = @match_header.match(aheader)
-        if md.nil? then
+        if md.nil?
           # header missing.
           script.unshift rheader
-        elsif md[:method] != ret[:method] or
-          md[:path] != ret[:path] or
-          md[:ctype] != ret[:content_type] then
+        elsif (
+          md[:method] != ret[:method] ||
+          md[:path] != ret[:path] ||
+          md[:ctype] != ret[:content_type]
+        )
           # header is wrong.
           script[0] = rheader
         end
         # otherwise current header is good.
 
         script = script.join("\n") + "\n"
-        if block_given? then
+        if block_given?
           yield script
         else
           script
@@ -105,23 +106,24 @@ module MrMurano
       # @param local [Pathname] path to file to push
       # @param remote [RouteItem] of method and endpoint path
       # @param modify [Boolean] True if item exists already and this is changing it
-      def upload(local, remote, modify)
-        local = Pathname.new(local) unless local.kind_of? Pathname
-        raise "no file" unless local.exist?
+      def upload(local, remote, _modify)
+        local = Pathname.new(local) unless local.is_a? Pathname
+        raise 'no file' unless local.exist?
         # we assume these are small enough to slurp.
-        if remote.script.nil? then
+        if remote.script.nil?
           script = local.read
           remote[:script] = script
         end
         limitkeys = [:method, :path, :script, :content_type, @itemkey]
-        remote = remote.to_h.select{|k,v| limitkeys.include? k }
+        remote = remote.to_h.select { |k, _v| limitkeys.include? k }
         #      post('', remote)
-        if remote.has_key? @itemkey then
+        if remote.is_a? @itemkey
           put('/' + remote[@itemkey], remote) do |request, http|
             response = http.request(request)
             case response
             when Net::HTTPSuccess
               #return JSON.parse(response.body)
+              return
             when Net::HTTPNotFound
               verbose "\tDoesn't exist, creating"
               post('/', remote)
@@ -141,26 +143,27 @@ module MrMurano
         delete('/' + id.to_s)
       end
 
-      def tolocalname(item, key)
+      def tolocalname(item, _key)
         name = ''
         # 2017-07-02: Changing shovel operator << to +=
         # to support Ruby 3.0 frozen string literals.
-        name += item[:path].split('/').reject { |i| i.empty? }.join('-')
+        name += item[:path].split('/').reject(&:empty?).join('-')
         name += '.'
         # This downcase is just for the filename.
         name += item[:method].downcase
         name += '.lua'
+        name
       end
 
-      def to_remote_item(from, path)
+      def to_remote_item(_from, path)
         # Path could be have multiple endpoints in side, so a loop.
         items = []
-        path = Pathname.new(path) unless path.kind_of? Pathname
+        path = Pathname.new(path) unless path.is_a? Pathname
         cur = nil
         lineno = 0
-        path.readlines().each do |line|
+        path.readlines.each do |line|
           md = @match_header.match(line)
-          if not md.nil? then
+          if !md.nil?
             # header line.
             cur[:line_end] = lineno unless cur.nil?
             items << cur unless cur.nil?
@@ -181,12 +184,12 @@ module MrMurano
               #method: md[:method],
               method: md[:method].upcase,
               path: md[:path],
-              content_type: (md[:ctype] or 'application/json'),
+              content_type: (md[:ctype] || 'application/json'),
               local_path: path,
               line: lineno,
               script: up_line,
             )
-          elsif not cur.nil? and not cur[:script].nil? then
+          elsif !cur.nil? && !cur[:script].nil?
             # 2017-07-02: Frozen string literal: change << to +=
             cur[:script] += line
           end
@@ -204,27 +207,27 @@ module MrMurano
         return false if md.nil?
         debug "match pattern: '#{md[:method]}' '#{md[:path]}'"
 
-        unless md[:method].empty? then
+        unless md[:method].empty?
           return false unless item[:method].casecmp(md[:method]).zero?
         end
 
         return true if md[:path].empty?
 
-        ::File.fnmatch(md[:path],item[:path])
+        ::File.fnmatch(md[:path], item[:path])
       end
 
       def synckey(item)
         "#{item[:method].upcase}_#{item[:path]}"
       end
 
-      def docmp(itemA, itemB)
-        if itemA[:script].nil? and itemA[:local_path] then
-          itemA[:script] = itemA[:local_path].read
+      def docmp(item_a, item_b)
+        if item_a[:script].nil? && item_a[:local_path]
+          item_a[:script] = item_a[:local_path].read
         end
-        if itemB[:script].nil? and itemB[:local_path] then
-          itemB[:script] = itemB[:local_path].read
+        if item_b[:script].nil? && item_b[:local_path]
+          item_b[:script] = item_b[:local_path].read
         end
-        return (itemA[:script] != itemB[:script] or itemA[:content_type] != itemB[:content_type])
+        (item_a[:script] != item_b[:script] || item_a[:content_type] != item_b[:content_type])
       end
     end
 

--- a/lib/MrMurano/Webservice-File.rb
+++ b/lib/MrMurano/Webservice-File.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -82,6 +82,7 @@ module MrMurano
       # @param path [String] The identifying key for this item
       def remove(path)
         path = path[1..-1] if path[0] == '/'
+        return unless remove_item_allowed(path)
         delete('/' + URI.encode_www_form_component(path))
       end
 
@@ -119,6 +120,9 @@ module MrMurano
         form = HTTP::FormData.create(file: file)
         req = Net::HTTP::Put.new(uri)
         add_headers(req)
+
+        return unless upload_item_allowed(remote[@itemkey])
+
         workit(req) do |request, http|
           request.content_type = form.content_type
           request.content_length = form.content_length

--- a/lib/MrMurano/Webservice-File.rb
+++ b/lib/MrMurano/Webservice-File.rb
@@ -1,5 +1,12 @@
+# Last Modified: 2017.08.20 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
 require 'digest/sha1'
-require "http/form_data"
+require 'http/form_data'
 require 'mime/types'
 require 'net/http'
 require 'uri'
@@ -50,12 +57,12 @@ module MrMurano
       # Get one item of the static content.
       def fetch(path, &block)
         path = path[1..-1] if path[0] == '/'
-        path = '/'+ URI.encode_www_form_component(path)
+        path = '/' + URI.encode_www_form_component(path)
         get(path) do |request, http|
           http.request(request) do |resp|
             case resp
             when Net::HTTPSuccess
-              if block_given? then
+              if block_given?
                 resp.read_body(&block)
               else
                 resp.read_body do |chunk|
@@ -81,9 +88,7 @@ module MrMurano
       def curldebug(request)
         # The upload will get printed out inside of upload.
         # Because we don't have the correct info here.
-        if request.method != 'PUT' then
-          super(request)
-        end
+        super(request) if request.method != 'PUT'
       end
 
       ##
@@ -91,8 +96,8 @@ module MrMurano
       # @param src [Pathname] Full path of where to upload from
       # @param item [Hash] The item details to upload
       # @param modify [Boolean] True if item exists already and this is changing it
-      def upload(local, remote, modify)
-        local = Pathname.new(local) unless local.kind_of? Pathname
+      def upload(local, remote, _modify)
+        local = Pathname.new(local) unless local.is_a? Pathname
 
         path = remote[:path]
         path = path[1..-1] if path[0] == '/'
@@ -110,22 +115,22 @@ module MrMurano
         # Most of these pull into ram.  So maybe just go with that. Would guess that
         # truely large static content is rare, and we can optimize/fix that later.
 
-        file = HTTP::FormData::File.new(local.to_s, { content_type: remote[:mime_type] })
+        file = HTTP::FormData::File.new(local.to_s, content_type: remote[:mime_type])
         form = HTTP::FormData.create(file: file)
         req = Net::HTTP::Put.new(uri)
-        set_def_headers(req)
+        add_headers(req)
         workit(req) do |request, http|
           request.content_type = form.content_type
           request.content_length = form.content_length
           request.body = form.to_s
 
-          if $cfg['tool.curldebug'] then
+          if $cfg['tool.curldebug']
             a = []
-            a << %{curl -s -H 'Authorization: #{request['authorization']}'}
-            a << %{-H 'User-Agent: #{request['User-Agent']}'}
-            a << %{-X #{request.method}}
-            a << %{'#{request.uri.to_s}'}
-            a << %{-F file=@#{local.to_s}}
+            a << %(curl -s -H 'Authorization: #{request['authorization']}')
+            a << %(-H 'User-Agent: #{request['User-Agent']}')
+            a << %(-X #{request.method})
+            a << %('#{request.uri}')
+            a << %(-F file=@#{local})
             if $cfg.curlfile_f.nil?
               puts a.join(' ')
             else
@@ -156,20 +161,22 @@ module MrMurano
         name = '/' if name == $cfg['files.default_page']
         name = "/#{name}" unless name.chars.first == '/'
 
-        mime = MIME::Types.type_for(path.to_s)[0] || MIME::Types["application/octet-stream"][0]
+        mime = MIME::Types.type_for(path.to_s)[0] || MIME::Types['application/octet-stream'][0]
 
         # It does not actually take the SHA1 of the file.
         # It first converts the file to hex, then takes the SHA1 of that string
         #sha1 = Digest::SHA1.file(path.to_s).hexdigest
         sha1 = Digest::SHA1.new
         path.open('rb:ASCII-8BIT') do |io|
-          while chunk = io.read(1048576) do
+          # rubocop:disable Lint/AssignmentInCondition
+          # "Assignment in condition - you probably meant to use ==."
+          while chunk = io.read(1_048_576)
             sha1 << Digest.hexencode(chunk)
           end
         end
         debug "Checking #{name} (#{mime.simplified} #{sha1.hexdigest})"
 
-        FileItem.new(:path=>name, :mime_type=>mime.simplified, :checksum=>sha1.hexdigest)
+        FileItem.new(path: name, mime_type: mime.simplified, checksum: sha1.hexdigest)
       end
 
       # @param item [FileItem] The item to get a key from
@@ -179,11 +186,11 @@ module MrMurano
       end
 
       # Compare items.
-      # @param itemA [FileItem]
-      # @param itemB [FileItem]
-      def docmp(itemA, itemB)
-        return (itemA[:mime_type] != itemB[:mime_type] or
-          itemA[:checksum] != itemB[:checksum])
+      # @param item_a [FileItem]
+      # @param item_b [FileItem]
+      def docmp(item_a, item_b)
+        (item_a[:mime_type] != item_b[:mime_type] ||
+        item_a[:checksum] != item_b[:checksum])
       end
     end
 

--- a/lib/MrMurano/commands/business.rb
+++ b/lib/MrMurano/commands/business.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -22,9 +22,10 @@ command :business do |c|
 Commands for working with businesses.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/business.rb
+++ b/lib/MrMurano/commands/business.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -185,7 +185,8 @@ def business_from_config
     if biz.valid?
       say("Found Business #{biz.pretty_name_and_id}")
     else
-      say("Could not find Business ‘#{biz.bid}’ referenced in the config")
+      biz_bid = MrMurano::Verbose.fancy_ticks(biz.bid)
+      say("Could not find Business #{biz_bid} referenced in the config")
     end
     puts('')
   end

--- a/lib/MrMurano/commands/business.rb
+++ b/lib/MrMurano/commands/business.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -10,7 +10,7 @@ require 'MrMurano/Account'
 require 'MrMurano/Business'
 require 'MrMurano/ReCommander'
 
-MSG_BUSINESSES_NONE_FOUND = 'No businesses found' if !defined? MSG_BUSINESSES_NONE_FOUND
+MSG_BUSINESSES_NONE_FOUND = 'No businesses found' unless defined? MSG_BUSINESSES_NONE_FOUND
 
 # *** Base business command help.
 # -------------------------------
@@ -49,19 +49,17 @@ def cmd_options_add_id_and_name(c)
 end
 
 def cmd_defaults_id_and_name(options)
-  if !options.id.nil? && !options.name.nil?
-    MrMurano::Verbose.error('Please only --id or --name but not both')
-    exit 1
-  end
+  return if options.id.nil? || options.name.nil?
+  MrMurano::Verbose.error('Please specify only --id or --name but not both')
+  exit 1
 end
 
 def cmd_verify_args_and_id_or_name!(args, options)
-  if !args.any? && (options.id || options.name)
-    MrMurano::Verbose.warning(
-      'The --id and --name options only apply when specifying a business name or ID.'
-    )
-    exit 1
-  end
+  return unless args.none? && (options.id || options.name)
+  MrMurano::Verbose.warning(
+    'The --id and --name options only apply when specifying a business name or ID.'
+  )
+  exit 1
 end
 
 def cmd_option_business_pickers(c)
@@ -123,7 +121,7 @@ Find business by name or ID.
   c.action do |args, options|
     # SKIP: c.verify_arg_count!(args)
     cmd_defaults_id_and_name(options)
-    if !args.any? && !any_business_pickers?(options)
+    if args.none? && !any_business_pickers?(options)
       MrMurano::Verbose.error('What would you like to find?')
       exit 1
     end
@@ -149,9 +147,9 @@ def business_find_or_ask!(acc, options)
     biz = businesses_ask_which(acc) if biz.nil?
   end
 
-  match_bid = $cfg.set('business.id', nil, :internal)
-  match_name = $cfg.set('business.name', nil, :internal)
-  match_fuzzy = $cfg.set('business.fuzzy', nil, :internal)
+  $cfg.set('business.id', nil, :internal)
+  $cfg.set('business.name', nil, :internal)
+  $cfg.set('business.fuzzy', nil, :internal)
 
   biz
 end

--- a/lib/MrMurano/commands/content.rb
+++ b/lib/MrMurano/commands/content.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -17,9 +17,10 @@ This set of commands let you interact with the content area for a product.
 This is where OTA data can be stored so that devices can easily download it.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -228,9 +228,8 @@ Enables Identifiers, creating devices, or digital shadows, in Murano.
         prd.error %(The --expire value is not a number of hours: #{prd.fancy_ticks(options.expire)})
         exit 1
       end
-      options.expire.to_i
       micros_since_epoch = DateTime.now.strftime('%Q').to_i * 1000
-      mircos_until_purge = options.expire.to_i * 60 * 1000 * 1000
+      mircos_until_purge = options.expire.to_i * 60 * 60 * 1000 * 1000
       options.expire = micros_since_epoch + mircos_until_purge
     end
 

--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -93,7 +93,7 @@ end
 alias_command 'devices list', 'device list'
 
 command 'device read' do |c|
-  c.syntax = %(murano device read <identifier> (<alias>...))
+  c.syntax = %(murano device read <identifier> [<alias>...] [--options])
   c.summary = %(Read state of a device)
   c.description = %(
 Read state of a device.
@@ -104,7 +104,7 @@ This reads the latest state values for the resources in a device.
   c.option '-o', '--output FILE', %(Download to file instead of STDOUT)
 
   c.action do |args, options|
-    c.verify_arg_count!(args, nil, ['Identifier missing'])
+    c.verify_arg_count!(args, nil, ['Missing device identifier'])
 
     prd = MrMurano::Gateway::Device.new
 
@@ -145,7 +145,7 @@ If an alias is not settable, this will fail.
   ).strip
 
   c.action do |args, _options|
-    c.verify_arg_count!(args, nil, ['Identifier missing'])
+    c.verify_arg_count!(args, nil, ['Missing device identifier'])
 
     resources = (MrMurano::Gateway::GweBase.new.info || {})[:resources]
 
@@ -299,7 +299,7 @@ you cannot retrive the CIK again.
   ).strip
 
   c.action do |args, _options|
-    c.verify_arg_count!(args, nil, ['Identifier missing'])
+    c.verify_arg_count!(args, nil, ['Missing device identifier'])
     prd = MrMurano::Gateway::Device.new
     prd.outf prd.activate(args.first)
   end
@@ -313,7 +313,7 @@ Delete a device.
   ).strip
 
   c.action do |args, _options|
-    c.verify_arg_count!(args, nil, ['Identifier missing'])
+    c.verify_arg_count!(args, nil, ['Missing device identifier'])
     prd = MrMurano::Gateway::Device.new
     snid = args.shift
     ret = prd.remove(snid)

--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -228,6 +228,10 @@ Enables Identifiers, creating devices, or digital shadows, in Murano.
         prd.error %(The --expire value is not a number of hours: #{prd.fancy_ticks(options.expire)})
         exit 1
       end
+      # The platform expects the expiration time to be an integer
+      # representing microseconds since the epoch, e.g.,
+      #    hours * mins/hour * secs/min * msec/sec * μsec/msec
+      # or hours * 60        * 60       * 1000     * 1000
       micros_since_epoch = DateTime.now.strftime('%Q').to_i * 1000
       mircos_until_purge = options.expire.to_i * 60 * 60 * 1000 * 1000
       options.expire = micros_since_epoch + mircos_until_purge

--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -198,7 +198,7 @@ Enables Identifiers, creating the digial shadow in Murano.
         exit 1
       end
       unless header =~ /\s*ID\s*(,SSL Client Certificate\s*)?/
-        prd.error "Missing column headers in file \"#{options.file}\""
+        prd.error %(Missing column headers in file "#{options.file}")
         prd.error %(First line in file should be either "ID" or "ID, SSL Client Certificate")
         exit 2
       end

--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -8,16 +8,17 @@
 require 'MrMurano/Gateway'
 require 'MrMurano/ReCommander'
 
-command 'device' do |c|
+command :device do |c|
   c.syntax = %(murano device)
   c.summary = %(Interact with a device)
   c.description = %(
 Interact with a device.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -6,7 +6,6 @@
 #  vim:tw=0:ts=2:sw=2:et:ai
 
 require 'date'
-require 'securerandom'
 require 'MrMurano/Gateway'
 require 'MrMurano/ReCommander'
 
@@ -383,43 +382,6 @@ This will revoke the device's keys and cause it to temporarily disconnect. The w
   end
 end
 
-command 'device token' do |c|
-  c.syntax = %(murano device revoke <identifier> (<token>|--random) [--options])
-  c.summary = %(Set authentication key token)
-  c.description = %(
-Set authentication key token.
-  ).strip
-
-  c.option '-r', '--random', %(Generate a random, 40 character token)
-
-  c.action do |args, options|
-    c.verify_arg_count!(args, 1, ['Missing device identifier'])
-
-    prd = MrMurano::Gateway::Device.new
-
-    if args.count < 2 && !options.random
-      prd.error %(Please specify a token or --random)
-      exit 1
-    elsif args.count > 1 && options.random
-      prd.error 'Please specify a token or --random but not both'
-      exit 1
-    end
-
-    if options.random
-      #pool = [*('a'..'z'), *('A'..'Z'), *('0'..'9')]
-      pool = [*('a'..'z'), *('0'..'9')]
-      token = [*0..39].map { |_| pool[SecureRandom.random_number(pool.length)] }.join('')
-    elsif args.count > 1
-      token = args[1]
-    else
-      raise 'Impossible'
-    end
-
-    prd.authenticize(args[0], token, :token)
-    puts token
-  end
-end
-
 alias_command 'product device', 'device'
 alias_command 'product device list', 'device list'
 alias_command 'product devices list', 'device list'
@@ -433,5 +395,4 @@ alias_command 'product device httpurl', 'device httpurl'
 alias_command 'product device lock', 'device lock'
 alias_command 'product device unlock', 'device unlock'
 alias_command 'product device revoke', 'device revoke'
-alias_command 'product device token', 'device token'
 

--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -225,7 +225,7 @@ Enables Identifiers, creating devices, or digital shadows, in Murano.
 
     unless options.expire.nil?
       unless options.expire =~ /^[0-9]+$/
-        prd.error %(The --expire value is not a number of hours: #{prd.fancy_tick(options.expire)})
+        prd.error %(The --expire value is not a number of hours: #{prd.fancy_ticks(options.expire)})
         exit 1
       end
       options.expire.to_i
@@ -247,7 +247,7 @@ Enables Identifiers, creating devices, or digital shadows, in Murano.
       begin
         header = File.new(options.file).gets
       rescue Errno::ENOENT => err
-        prd.error %(Unable to open file #{prd.fancy_tick(options.file)}: #{err.message})
+        prd.error %(Unable to open file #{prd.fancy_ticks(options.file)}: #{err.message})
         exit 2
       end
       if header.nil?

--- a/lib/MrMurano/commands/globals.rb
+++ b/lib/MrMurano/commands/globals.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.21 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -56,6 +56,10 @@ global_option('--[no-]plugins', %(Do not load plugins. Good for when one goes ba
 
 global_option('--[no-]progress', %(Disable spinner and progress message)) do |value|
   $cfg['tool.no-progress'] = !value
+end
+
+global_option('--[no-]ascii', %(Use only ASCII in output)) do |value|
+  $cfg['tool.ascii'] = value
 end
 
 global_option('-V', '--verbose', %(Be chatty)) do

--- a/lib/MrMurano/commands/globals.rb
+++ b/lib/MrMurano/commands/globals.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.21 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -50,7 +50,9 @@ global_option('--exclude-scopes SCOPES', Array, exclude_help) do |value|
 end
 
 # --no-page is handled early on, in bin/murano.
-global_option('--no-page', %(Do not page --help output))
+global_option('--[no-]page', %(Do not page --help output)) do |value|
+  $cfg['tool.no-page'] = !value
+end
 
 global_option('--[no-]plugins', %(Do not load plugins. Good for when one goes bad))
 

--- a/lib/MrMurano/commands/keystore.rb
+++ b/lib/MrMurano/commands/keystore.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -18,9 +18,10 @@ in a solution. This allows for easier debugging, being able to quickly get and
 set data. As well as calling any of the other supported REDIS commands.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/link.rb
+++ b/lib/MrMurano/commands/link.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -190,9 +190,8 @@ def link_solutions(sol_a, sol_b, options)
       elsif response.is_a?(Net::HTTPConflict)
         svc_cfg_exists = true
       else
-        MrMurano::Verbose.error(
-          "Unable to link solutions: ‘#{Rainbow(response.message).underline}’"
-        )
+        resp_msg = MrMurano::Verbose.fancy_ticks(Rainbow(response.message).underline)
+        MrMurano::Verbose.error("Unable to link solutions: #{resp_msg}")
         sercfg.showHttpError(request, response)
       end
     end
@@ -227,9 +226,8 @@ def link_solutions(sol_a, sol_b, options)
       elsif response.is_a?(Net::HTTPConflict)
         evt_hlr_exists = true
       else
-        MrMurano::Verbose.error(
-          "Failed to create default event handler: ‘#{Rainbow(response.message).underline}’"
-        )
+        resp_msg = MrMurano::Verbose.fancy_ticks(Rainbow(response.message).underline)
+        MrMurano::Verbose.error("Failed to create default event handler: #{resp_msg}")
         evthlr.showHttpError(request, response)
       end
     end
@@ -265,11 +263,11 @@ def unlink_solutions(sol_a, sol_b)
     sercfg.debug "Deleting #{svc[:service]} : #{svc[:script_key]} : #{svc[:id]}"
     ret = sercfg.remove(svc[:id])
     if !ret.nil?
-      msg = "Unlinked ‘#{svc[:script_key]}’"
+      msg = "Unlinked #{MrMurano::Verbose.fancy_ticks(svc[:script_key])}"
       msg += " from #{sol_a.quoted_name}" unless sol_a.quoted_name.to_s.empty?
       say(msg)
     else
-      sercfg.warning "Failed to unlink ‘#{svc[:id]}’"
+      sercfg.warning "Failed to unlink #{MrMurano::Verbose.fancy_ticks(svc[:id])}"
     end
   end
 
@@ -290,11 +288,12 @@ def unlink_solutions(sol_a, sol_b)
     evthlr.debug "Deleting #{evth[:service]} : #{evth[:alias]} : #{evth[:id]}"
     ret = evthlr.remove(evth[:id])
     if !ret.nil?
-      msg = "Removed ‘#{evth[:alias]}’"
+      msg = "Removed #{MrMurano::Verbose.fancy_ticks(evth[:alias])}"
       msg += " from #{sol_a.quoted_name}" unless sol_a.quoted_name.to_s.empty?
       say(msg)
     else
-      MrMurano::Verbose.warning "Failed to remove handler ‘#{svc[:id]}’"
+      svc_id = MrMurano::Verbose.fancy_ticks(svc[:id])
+      MrMurano::Verbose.warning "Failed to remove handler #{svc_id}"
     end
   end
 end

--- a/lib/MrMurano/commands/link.rb
+++ b/lib/MrMurano/commands/link.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -13,16 +13,17 @@ require 'MrMurano/SolutionId'
 
 MSG_SERVICE_LINKS_NONE_FOUND = 'No service links found' unless defined? MSG_SERVICE_LINKS_NONE_FOUND
 
-command 'link' do |c|
+command :link do |c|
   c.syntax = %(murano link)
   c.summary = %(Use the link commands to manage solution links)
   c.description = %(
 Use the link commands to manage solution links.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say(MrMurano::SubCmdGroupHelp.new(c).get_help)
   end
 end

--- a/lib/MrMurano/commands/login.rb
+++ b/lib/MrMurano/commands/login.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -75,7 +75,8 @@ Essentially, this command is the same as:
     cfg_val = $cfg.get(cfg_key)
     if cfg_val.to_s.empty?
       cfg_val = nil
-      MrMurano::Verbose.warning("No config key ‘#{cfg_key}’: no password to delete")
+      cfg_key_q = MrMurano::Verbose.fancy_ticks(cfg_key)
+      MrMurano::Verbose.warning("No config key #{cfg_key_q}: no password to delete")
     end
     cfg_val
   end

--- a/lib/MrMurano/commands/mock.rb
+++ b/lib/MrMurano/commands/mock.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -8,16 +8,17 @@
 require 'MrMurano/Mock'
 require 'MrMurano/ReCommander'
 
-command 'mock' do |c|
+command :mock do |c|
   c.syntax = %(murano mock)
   c.summary = %(Enable or disable testpoint, or show current UUID)
   c.description = %(
 The mock command lets you enable testpoints to do local Lua development.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/password.rb
+++ b/lib/MrMurano/commands/password.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -14,8 +14,10 @@ command :password do |c|
 Commands for working with usernames and passwords.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
+
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/postgresql.rb
+++ b/lib/MrMurano/commands/postgresql.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -125,7 +125,9 @@ extra table in your database. (__murano_cli__.migrate_version)
 
   c.action do |args, options|
     c.verify_arg_count!(args, 2, ['Missing direction'])
-    options.default(dir: File.join($cfg['location.base'], ($cfg['postgresql.migrations_dir'] || '')))
+    options.default(
+      dir: File.join($cfg['location.base'], ($cfg['postgresql.migrations_dir'] || '')),
+    )
 
     pg = MrMurano::Postgresql.new
 
@@ -135,7 +137,7 @@ extra table in your database. (__murano_cli__.migrate_version)
     elsif direction =~ /up/i
       direction = 'up'
     else
-      pg.error "Unrecogized direction: ‘#{direction}’"
+      pg.error "Unrecognized direction: #{MrMurano::Verbose.fancy_ticks(direction)}"
       exit 1
     end
 

--- a/lib/MrMurano/commands/settings.rb
+++ b/lib/MrMurano/commands/settings.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -11,11 +11,26 @@ require 'MrMurano/hash'
 require 'MrMurano/ReCommander'
 require 'MrMurano/Setting'
 
+command :setting do |c|
+  c.syntax = %(murano setting)
+  c.summary = %(Use the setting commands to manage service settings)
+  c.description = %(
+Use the setting commands to manage service settings.
+  ).strip
+  c.project_not_required = true
+  c.subcmdgrouphelp = true
+
+  c.action do |_args, _options|
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
+    say(MrMurano::SubCmdGroupHelp.new(c).get_help)
+  end
+end
+
 command 'setting list' do |c|
   c.syntax = %(murano setting list)
-  c.summary = %(List which services and settings are avalible.)
+  c.summary = %(List which services and settings are available)
   c.description = %(
-List which services and settings are avalible.
+List which services and settings are available.
   ).strip
   c.project_not_required = true
 

--- a/lib/MrMurano/commands/settings.rb
+++ b/lib/MrMurano/commands/settings.rb
@@ -1,3 +1,10 @@
+# Last Modified: 2017.08.20 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
 require 'vine'
 require 'yaml'
 require 'MrMurano/hash'
@@ -5,14 +12,14 @@ require 'MrMurano/ReCommander'
 require 'MrMurano/Setting'
 
 command 'setting list' do |c|
-  c.syntax = %{murano setting list}
-  c.summary = %{List which services and settings are avalible.}
-  c.description = %{
+  c.syntax = %(murano setting list)
+  c.summary = %(List which services and settings are avalible.)
+  c.description = %(
 List which services and settings are avalible.
-  }.strip
+  ).strip
   c.project_not_required = true
 
-  c.action do |args, options|
+  c.action do |args, _options|
     c.verify_arg_count!(args)
 
     setting = MrMurano::Setting.new
@@ -20,7 +27,7 @@ List which services and settings are avalible.
     ret = setting.list
 
     dd = []
-    ret.each_pair { |k,v| v.each { |s| dd << "#{k}.#{s}" } }
+    ret.each_pair { |k, v| v.each { |s| dd << "#{k}.#{s}" } }
 
     setting.outf dd
   end
@@ -28,13 +35,13 @@ end
 alias_command 'settings list', 'setting list'
 
 command 'setting read' do |c|
-  c.syntax = %{murano setting read <service>.<setting> [<sub-key>]}
-  c.summary = %{Read a setting on a Service}
-  c.description = %{
+  c.syntax = %(murano setting read <service>.<setting> [<sub-key>])
+  c.summary = %(Read a setting on a Service)
+  c.description = %(
 Read a setting on a Service.
-  }.strip
+  ).strip
 
-  c.option '-o', '--output FILE', String, %{File to save output to}
+  c.option '-o', '--output FILE', String, %(File to save output to)
 
   c.action do |args, options|
     c.verify_arg_count!(args, 2, ['Missing <service>.<setting>'])
@@ -49,18 +56,16 @@ Read a setting on a Service.
     ret = ret.access(subkey) unless subkey.nil?
 
     io = nil
-    if options.output then
-      io = File.open(options.output, 'w')
-    end
+    io = File.open(options.output, 'w') if options.output
     setting.outf(ret, io)
     io.close unless io.nil?
   end
 end
 
 command 'setting write' do |c|
-  c.syntax = %{murano setting write <service>.<setting> <sub-key> [<value>...]}
-  c.summary = %{Write a setting on a Service}
-  c.description = %{
+  c.syntax = %(murano setting write <service>.<setting> <sub-key> [<value>...])
+  c.summary = %(Write a setting on a Service)
+  c.description = %(
 Write a setting on a Service, or just part of a setting.
 
 if <value> is omitted on command line, then it is read from STDIN.
@@ -68,25 +73,25 @@ if <value> is omitted on command line, then it is read from STDIN.
 This always does a read-modify-write.
 
 If a sub-key doesn't exist, that entire path will be created as dicts.
-  }.strip
+  ).strip
 
-  c.option '--bool', %{Set Value type to boolean}
-  c.option '--num', %{Set Value type to number}
-  c.option '--string', %{Set Value type to string (this is default)}
-  c.option '--json', %{Value is parsed as JSON}
-  c.option '--array', %{Set Value type to array of strings}
-  c.option '--dict', %{Set Value type to a dictionary of strings}
+  c.option '--bool', %(Set Value type to boolean)
+  c.option '--num', %(Set Value type to number)
+  c.option '--string', %(Set Value type to string (this is default))
+  c.option '--json', %(Value is parsed as JSON)
+  c.option '--array', %(Set Value type to array of strings)
+  c.option '--dict', %(Set Value type to a dictionary of strings)
 
-  c.option '--append', %{When sub-key is an array, append values instead of replacing}
-  c.option '--merge', %{When sub-key is a dict, merge values instead of replacing (child dicts are also merged)}
+  c.option '--append', %(When sub-key is an array, append values instead of replacing)
+  c.option '--merge', %(When sub-key is a dict, merge values instead of replacing (child dicts are also merged))
 
-  c.example %{murano setting write Gateway.protocol devmode --bool yes}, %{}
-  c.example %{murano setting write Gateway.identity_format options.length --int 24}, %{}
+  c.example %(murano setting write Gateway.protocol devmode --bool yes), %()
+  c.example %(murano setting write Gateway.identity_format options.length --int 24), %()
 
-  c.example %{murano setting write Webservice.cors methods --array HEAD GET POST}, %{}
-  c.example %{murano setting write Webservice.cors headers --append --array X-My-Token}, %{}
+  c.example %(murano setting write Webservice.cors methods --array HEAD GET POST), %()
+  c.example %(murano setting write Webservice.cors headers --append --array X-My-Token), %()
 
-  c.example %{murano setting write Webservice.cors --type=json - < }, %{}
+  c.example %(murano setting write Webservice.cors --type=json - < ), %()
 
   c.action do |args, options|
     c.verify_arg_count!(args, nil, ['Missing <service>.<setting>', 'Missing <sub-key>'])
@@ -108,63 +113,61 @@ If a sub-key doesn't exist, that entire path will be created as dicts.
     setting = MrMurano::Setting.new
 
     # If value is '-', pull from $stdin
-    if value.nil? and args.count == 0 then
-      value = $stdin.read
-    end
+    value = $stdin.read if value.nil? && args.count == 0
 
     # Set value to correct type.
-    if options.bool then
-      if value =~ /(yes|y|true|t|1|on)/i then
+    if options.bool
+      if value =~ /(yes|y|true|t|1|on)/i
         value = true
-      elsif value =~ /(no|n|false|f|0|off)/i then
+      elsif value =~ /(no|n|false|f|0|off)/i
         value = false
       else
-        setting.error %{Value "#{value}" is not a bool type!}
+        setting.error %(Value "#{value}" is not a bool type!)
         exit 2
       end
-    elsif options.num then
+    elsif options.num
       begin
         value = Integer(value)
-      rescue Exception => e
+      rescue StandardError => e
         setting.debug e.to_s
         begin
           value = Float(value)
-        rescue Exception => e
-          setting.error %{Value "#{value}" is not a number}
+        rescue StandardError => e
+          setting.error %(Value "#{value}" is not a number)
           setting.debug e.to_s
           exit 2
         end
       end
-    elsif options.json then
+    elsif options.json
       # We use the YAML parser since it will handle most common typos in json and
       # product the intended output.
       begin
         value = YAML.load(value)
-      rescue Exception => e
-        setting.error %{Value not valid JSON (or YAML)}
+      rescue StandardError => e
+        setting.error %(Value not valid JSON (or YAML))
         setting.debug e.to_s
         exit 2
       end
 
-    elsif options.array then
+    elsif options.array
       # take remaining args as an array
       value = args
 
-    elsif options.dict then
+    elsif options.dict
       # take remaining args and convert to hash
       begin
         value = Hash.transform_keys_to_symbols(Hash[*args])
       rescue ArgumentError => e
-        setting.error %{Odd number of arguments to dictionary}
+        setting.error %(Odd number of arguments to dictionary)
         setting.debug e.to_s
         exit 2
-      rescue Exception => e
-        setting.error %{Cannot make dictionary from args}
+      rescue StandardError => e
+        setting.error %(Cannot make dictionary from args)
         setting.debug e.to_s
         exit 2
       end
 
-    elsif options.string then
+    elsif options.string
       value = value.to_s
     else
       # is a string.
@@ -172,32 +175,30 @@ If a sub-key doesn't exist, that entire path will be created as dicts.
     end
 
     ret = setting.read(service, pref)
-    setting.verbose %{Read value: #{ret}}
+    setting.verbose %(Read value: #{ret})
 
     # modify and merge.
-    if options.append then
+    if options.append
       g = ret.access(subkey)
-      unless g.kind_of? Array then
-        setting.error %{Cannot append; "#{subkey}" is not an array.}
+      unless g.is_a? Array
+        setting.error %(Cannot append; "#{subkey}" is not an array.)
         exit 3
       end
       g.push(*value)
 
-    elsif options.merge then
+    elsif options.merge
       g = ret.access(subkey)
-      unless g.kind_of? Hash then
-        setting.error %{Cannot append; "#{subkey}" is not a dictionary.}
+      unless g.is_a? Hash
+        setting.error %(Cannot append; "#{subkey}" is not a dictionary.)
         exit 3
       end
       g.deep_merge!(value)
     else
       ret.set(subkey, value)
     end
-    setting.verbose %{Going to write composed value: #{ret}}
+    setting.verbose %(Going to write composed value: #{ret})
 
     setting.write(service, pref, ret)
   end
 end
-
-#  vim: set ai et sw=2 ts=2 :
 

--- a/lib/MrMurano/commands/show.rb
+++ b/lib/MrMurano/commands/show.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -20,7 +20,7 @@ Show readable information about the current configuration.
 
   c.option '--[no-]ids', 'Show IDs'
 
-  c.action do |args, _options|
+  c.action do |args, options|
     if args.include?('help')
       ::Commander::UI.enable_paging
       say MrMurano::SubCmdGroupHelp.new(c).get_help
@@ -64,7 +64,7 @@ Show readable information about the current configuration.
 
       if selected_business
         biz_info = %(business: #{selected_business.name})
-        biz_info += %( <#{selected_business.bid}>)
+        biz_info += %( <#{selected_business.bid}>) if options.ids
         puts biz_info
       else
         #puts 'no business selected'
@@ -77,7 +77,7 @@ Show readable information about the current configuration.
       #        :name=>"ABC", :domain=>"ABC.apps.exosite.io" }
       if selected_application
         sol_info = %(application: https://#{selected_application.domain})
-        sol_info += %( <#{selected_application.sid}>)
+        sol_info += %( <#{selected_application.sid}>) if options.ids
         puts sol_info
       elsif selected_application_id
         #puts 'selected application not in business'
@@ -94,7 +94,7 @@ Show readable information about the current configuration.
       #        :name=>"ABC", :domain=>"ABC.m2.exosite.io" }
       if selected_product
         sol_info = %(product: #{selected_product.name})
-        sol_info += %( <#{selected_product.sid}>)
+        sol_info += %( <#{selected_product.sid}>) if options.ids
         puts sol_info
       elsif selected_product_id
         #puts 'selected product not in business'

--- a/lib/MrMurano/commands/show.rb
+++ b/lib/MrMurano/commands/show.rb
@@ -18,6 +18,8 @@ Show readable information about the current configuration.
   ).strip
   c.project_not_required = true
 
+  c.option '--[no-]ids', 'Show IDs'
+
   c.action do |args, _options|
     if args.include?('help')
       ::Commander::UI.enable_paging
@@ -61,7 +63,9 @@ Show readable information about the current configuration.
       end
 
       if selected_business
-        puts %(business: #{selected_business.name})
+        biz_info = %(business: #{selected_business.name})
+        biz_info += %( <#{selected_business.bid}>)
+        puts biz_info
       else
         #puts 'no business selected'
         MrMurano::Verbose.error MrMurano::Business.missing_business_id_msg
@@ -72,7 +76,9 @@ Show readable information about the current configuration.
       # E.g., {:bizid=>"ABC", :type=>"application", :apiId=>"XXX", :sid=>"XXX",
       #        :name=>"ABC", :domain=>"ABC.apps.exosite.io" }
       if selected_application
-        puts %(application: https://#{selected_application.domain})
+        sol_info = %(application: https://#{selected_application.domain})
+        sol_info += %( <#{selected_application.sid}>)
+        puts sol_info
       elsif selected_application_id
         #puts 'selected application not in business'
         puts "application ID from config is not in business (#{selected_application_id})"
@@ -87,7 +93,9 @@ Show readable information about the current configuration.
       # E.g., {:bizid=>"ABC", :type=>"product", :apiId=>"XXX", :sid=>"XXX",
       #        :name=>"ABC", :domain=>"ABC.m2.exosite.io" }
       if selected_product
-        puts %(product: #{selected_product.name})
+        sol_info = %(product: #{selected_product.name})
+        sol_info += %( <#{selected_product.sid}>)
+        puts sol_info
       elsif selected_product_id
         #puts 'selected product not in business'
         puts "product ID from config is not in business (#{selected_product_id})"

--- a/lib/MrMurano/commands/show.rb
+++ b/lib/MrMurano/commands/show.rb
@@ -10,7 +10,7 @@ require 'MrMurano/Business'
 require 'MrMurano/ReCommander'
 require 'MrMurano/Solution'
 
-command 'show' do |c|
+command :show do |c|
   c.syntax = %(murano show)
   c.summary = %(Show readable information about the current configuration)
   c.description = %(
@@ -21,94 +21,91 @@ Show readable information about the current configuration.
   c.option '--[no-]ids', 'Show IDs'
 
   c.action do |args, options|
-    if args.include?('help')
-      ::Commander::UI.enable_paging
-      say MrMurano::SubCmdGroupHelp.new(c).get_help
-    else
-      acc = MrMurano::Account.instance
-      biz = MrMurano::Business.new
+    c.verify_arg_count!(args)
 
-      selected_business = nil
-      selected_business_id = $cfg['business.id']
-      unless selected_business_id.to_s.empty?
-        acc.businesses.each do |sol|
-          selected_business = sol if sol.bizid == selected_business_id
-        end
+    acc = MrMurano::Account.instance
+    biz = MrMurano::Business.new
+
+    selected_business = nil
+    selected_business_id = $cfg['business.id']
+    unless selected_business_id.to_s.empty?
+      acc.businesses.each do |sol|
+        selected_business = sol if sol.bizid == selected_business_id
       end
-
-      selected_application = nil
-      selected_application_id = $cfg['application.id']
-      unless selected_application_id.to_s.empty?
-        MrMurano::Verbose.whirly_start('Fetching Applications...')
-        biz.applications.each do |sol|
-          selected_application = sol if sol.apiId == selected_application_id
-        end
-        MrMurano::Verbose.whirly_stop
-      end
-
-      selected_product = nil
-      selected_product_id = $cfg['product.id']
-      unless selected_product_id.to_s.empty?
-        MrMurano::Verbose.whirly_start('Fetching Products...')
-        biz.products.each do |sol|
-          selected_product = sol if sol.apiId == selected_product_id
-        end
-        MrMurano::Verbose.whirly_stop
-      end
-
-      if $cfg['user.name']
-        puts %(user: #{$cfg['user.name']})
-      else
-        puts 'no user selected'
-      end
-
-      if selected_business
-        biz_info = %(business: #{selected_business.name})
-        biz_info += %( <#{selected_business.bid}>) if options.ids
-        puts biz_info
-      else
-        #puts 'no business selected'
-        MrMurano::Verbose.error MrMurano::Business.missing_business_id_msg
-      end
-
-      id_not_in_biz = false
-
-      # E.g., {:bizid=>"ABC", :type=>"application", :apiId=>"XXX", :sid=>"XXX",
-      #        :name=>"ABC", :domain=>"ABC.apps.exosite.io" }
-      if selected_application
-        sol_info = %(application: https://#{selected_application.domain})
-        sol_info += %( <#{selected_application.sid}>) if options.ids
-        puts sol_info
-      elsif selected_application_id
-        #puts 'selected application not in business'
-        puts "application ID from config is not in business (#{selected_application_id})"
-        id_not_in_biz = true
-      elsif !selected_business
-        puts 'application ID depends on business ID'
-      else
-        #puts 'no application selected'
-        puts 'application ID not found in config'
-      end
-
-      # E.g., {:bizid=>"ABC", :type=>"product", :apiId=>"XXX", :sid=>"XXX",
-      #        :name=>"ABC", :domain=>"ABC.m2.exosite.io" }
-      if selected_product
-        sol_info = %(product: #{selected_product.name})
-        sol_info += %( <#{selected_product.sid}>) if options.ids
-        puts sol_info
-      elsif selected_product_id
-        #puts 'selected product not in business'
-        puts "product ID from config is not in business (#{selected_product_id})"
-        id_not_in_biz = true
-      elsif !selected_business
-        puts 'product ID depends on business ID'
-      else
-        #puts 'no product selected'
-        puts 'product ID not found in config'
-      end
-
-      MrMurano::SolutionBase.warn_configfile_env_maybe if id_not_in_biz
     end
+
+    selected_application = nil
+    selected_application_id = $cfg['application.id']
+    unless selected_application_id.to_s.empty?
+      MrMurano::Verbose.whirly_start('Fetching Applications...')
+      biz.applications.each do |sol|
+        selected_application = sol if sol.apiId == selected_application_id
+      end
+      MrMurano::Verbose.whirly_stop
+    end
+
+    selected_product = nil
+    selected_product_id = $cfg['product.id']
+    unless selected_product_id.to_s.empty?
+      MrMurano::Verbose.whirly_start('Fetching Products...')
+      biz.products.each do |sol|
+        selected_product = sol if sol.apiId == selected_product_id
+      end
+      MrMurano::Verbose.whirly_stop
+    end
+
+    if $cfg['user.name']
+      puts %(user: #{$cfg['user.name']})
+    else
+      puts 'no user selected'
+    end
+
+    if selected_business
+      biz_info = %(business: #{selected_business.name})
+      biz_info += %( <#{selected_business.bid}>) if options.ids
+      puts biz_info
+    else
+      #puts 'no business selected'
+      MrMurano::Verbose.error MrMurano::Business.missing_business_id_msg
+    end
+
+    id_not_in_biz = false
+
+    # E.g., {:bizid=>"ABC", :type=>"application", :apiId=>"XXX", :sid=>"XXX",
+    #        :name=>"ABC", :domain=>"ABC.apps.exosite.io" }
+    if selected_application
+      sol_info = %(application: https://#{selected_application.domain})
+      sol_info += %( <#{selected_application.sid}>) if options.ids
+      puts sol_info
+    elsif selected_application_id
+      #puts 'selected application not in business'
+      puts "application ID from config is not in business (#{selected_application_id})"
+      id_not_in_biz = true
+    elsif !selected_business
+      puts 'application ID depends on business ID'
+    else
+      #puts 'no application selected'
+      puts 'application ID not found in config'
+    end
+
+    # E.g., {:bizid=>"ABC", :type=>"product", :apiId=>"XXX", :sid=>"XXX",
+    #        :name=>"ABC", :domain=>"ABC.m2.exosite.io" }
+    if selected_product
+      sol_info = %(product: #{selected_product.name})
+      sol_info += %( <#{selected_product.sid}>) if options.ids
+      puts sol_info
+    elsif selected_product_id
+      #puts 'selected product not in business'
+      puts "product ID from config is not in business (#{selected_product_id})"
+      id_not_in_biz = true
+    elsif !selected_business
+      puts 'product ID depends on business ID'
+    else
+      #puts 'no product selected'
+      puts 'product ID not found in config'
+    end
+
+    MrMurano::SolutionBase.warn_configfile_env_maybe if id_not_in_biz
   end
 end
 

--- a/lib/MrMurano/commands/show.rb
+++ b/lib/MrMurano/commands/show.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.

--- a/lib/MrMurano/commands/solution.rb
+++ b/lib/MrMurano/commands/solution.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -157,7 +157,7 @@ def cmd_solution_del_get_names_and_ids!(biz, args, options)
   end
   solz = must_fetch_solutions!(options, args, biz)
   solz.each do |sol|
-    nmorids += [[sol.sid, "‘#{sol.name}’ <#{sol.sid}>", sol]]
+    nmorids += [[sol.sid, "#{MrMurano::Verbose.fancy_ticks(sol.name)} <#{sol.sid}>", sol]]
   end
   nmorids
 end
@@ -231,7 +231,8 @@ def solution_delete(name_or_id, use_sol: nil, type: :all, yes: false)
   n_faulted = 0
   if solz.empty?
     if !name_or_id.empty?
-      MrMurano::Verbose.error("No solution matching ‘#{name_or_id}’ found")
+      name_or_id_q = MrMurano::Verbose.fancy_ticks(name_or_id)
+      MrMurano::Verbose.error("No solution matching #{name_or_id_q} found")
     else
       MrMurano::Verbose.error(MSG_SOLUTIONS_NONE_FOUND)
     end

--- a/lib/MrMurano/commands/solution.rb
+++ b/lib/MrMurano/commands/solution.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -19,9 +19,10 @@ command :solution do |c|
 Commands for working with Application and Product solutions.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/solution_picker.rb
+++ b/lib/MrMurano/commands/solution_picker.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -156,12 +156,12 @@ def must_fetch_solutions!(options, args=[], biz=nil)
 
   if args.none? && !any_solution_pickers!(options)
     if !options.all
-      if $cfg['application.id']
+      if %i[all application].include?(options.type) && $cfg['application.id']
         solz += solution_get_solutions(
           biz, :application, sid: $cfg['application.id']
         )
       end
-      if $cfg['product.id']
+      if %i[all product].include?(options.type) && $cfg['product.id']
         solz += solution_get_solutions(
           biz, :product, sid: $cfg['product.id']
         )

--- a/lib/MrMurano/commands/solution_picker.rb
+++ b/lib/MrMurano/commands/solution_picker.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -449,7 +449,8 @@ module MrMurano
             say "Found #{sol.type_name} #{sol.pretty_desc}"
           elsif !@searching
             # The solution ID in the config was not found for this business.
-            say "The #{sol.type_name} ID ‘#{tried_sid}’ from the config was not found"
+            tried_sid = MrMurano::Verbose.fancy_ticks(tried_sid)
+            say "The #{sol.type_name} ID #{tried_sid} from the config was not found"
           end
           puts ''
         end

--- a/lib/MrMurano/commands/status.rb
+++ b/lib/MrMurano/commands/status.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.18 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -109,6 +109,7 @@ Endpoints can be selected with a "#<method>#<path glob>" pattern.
       unless item[:pp_desc].to_s.empty? || item[:pp_desc] == item[:synckey]
         desc += " (#{item[:pp_desc]})"
       end
+      # NOTE: This path is the endpoint path.
       desc += " [#{item[:method]} #{item[:path]}]" if item[:method] && item[:path]
       desc
     end
@@ -149,6 +150,16 @@ Endpoints can be selected with a "#<method>#<path glob>" pattern.
         end
       end
 
+      unless ret[:clash].empty?
+        pretty_group_header(
+          ret[:clash], 'Conflicting items', 'in conflict', options.grouped
+        )
+        ret[:clash].each do |item|
+          abbrev = $cfg['tool.ascii'] && 'x' || '✗'
+          interject " #{abbrev} #{item[:pp_type]}  #{highlight_del(fmtr(item, options))}"
+        end
+      end
+
       return unless options.show_all
       interject 'Unchanged:' if options.grouped
       ret[:unchg].each { |item| interject "   #{item[:pp_type]}  #{fmtr(item, options)}" }
@@ -171,15 +182,15 @@ Endpoints can be selected with a "#<method>#<path glob>" pattern.
       Rainbow(msg).red.bright
     end
 
-    @grouped = { toadd: [], todel: [], tomod: [], unchg: [], skipd: [] }
+    @grouped = { toadd: [], todel: [], tomod: [], unchg: [], skipd: [], clash: [] }
     def gmerge(ret, type, desc, options)
       if options.grouped
         out = @grouped
       else
-        out = { toadd: [], todel: [], tomod: [], unchg: [], skipd: [] }
+        out = { toadd: [], todel: [], tomod: [], unchg: [], skipd: [], clash: [] }
       end
 
-      %i[toadd todel tomod unchg skipd].each do |kind|
+      %i[toadd todel tomod unchg skipd clash].each do |kind|
         ret[kind].each do |item|
           item = item.to_h
           item[:pp_type] = type

--- a/lib/MrMurano/commands/timeseries.rb
+++ b/lib/MrMurano/commands/timeseries.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -42,9 +42,10 @@ The timeseries sub-commands let you interact directly with the Timeseries
 instance in a solution. This allows for easier debugging, being able to
 quickly try out different queries or write test data.
   ).strip
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/commands/tsdb.rb
+++ b/lib/MrMurano/commands/tsdb.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -59,9 +59,10 @@ solution. This allows for easier debugging, being able to quickly try out
 different queries or write test data.
   ).strip
   c.project_not_required = true
+  c.subcmdgrouphelp = true
 
   c.action do |_args, _options|
-    ::Commander::UI.enable_paging
+    ::Commander::UI.enable_paging unless $cfg['tool.no-page']
     say MrMurano::SubCmdGroupHelp.new(c).get_help
   end
 end

--- a/lib/MrMurano/hash.rb
+++ b/lib/MrMurano/hash.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -14,8 +14,8 @@ class Hash
   # Take keys of hash and transform those to symbols.
   def self.transform_keys_to_symbols(value)
     return value.map { |v| Hash.transform_keys_to_symbols(v) } if value.is_a?(Array)
-    return value if not value.is_a?(Hash)
-    value.inject({}) { |memo, (k,v)| memo[k.to_sym] = Hash.transform_keys_to_symbols(v); memo }
+    return value unless value.is_a?(Hash)
+    value.inject({}) { |memo, (k, v)| memo[k.to_sym] = Hash.transform_keys_to_symbols(v); memo }
   end
 
   # From:
@@ -24,8 +24,8 @@ class Hash
   # Take keys of hash and transform those to strings.
   def self.transform_keys_to_strings(value)
     return value.map { |v| Hash.transform_keys_to_strings(v) } if value.is_a?(Array)
-    return value if not value.is_a?(Hash)
-    value.inject({}) { |memo, (k,v)| memo[k.to_s] = Hash.transform_keys_to_strings(v); memo }
+    return value unless value.is_a?(Hash)
+    value.inject({}) { |memo, (k, v)| memo[k.to_s] = Hash.transform_keys_to_strings(v); memo }
   end
 
   # From Rails.
@@ -35,7 +35,7 @@ class Hash
       if this_value.is_a?(Hash) && other_value.is_a?(Hash)
         self[current_key] = this_value.deep_merge(other_value, &block)
       elsif block_given? && key?(current_key)
-        self[current_key] = block.call(current_key, this_value, other_value)
+        self[current_key] = yield(current_key, this_value, other_value)
       else
         self[current_key] = other_value
       end

--- a/lib/MrMurano/makePretty.rb
+++ b/lib/MrMurano/makePretty.rb
@@ -1,20 +1,27 @@
+# Last Modified: 2017.08.20 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
 require 'date'
 require 'json'
 require 'highline'
 
 module MrMurano
   module Pretties
-
-    HighLine::Style.new(:name=>:on_aliceblue, :code=>"\e[48;5;231m", :rgb=>[240, 248, 255])
+    HighLine::Style.new(name: :on_aliceblue, code: "\e[48;5;231m", rgb: [240, 248, 255])
     PRETTIES_COLORSCHEME = HighLine::ColorScheme.new do |cs|
-      cs[:subject] = [:red, :on_aliceblue]
+      cs[:subject] = %i[red on_aliceblue]
       cs[:timestamp] = [:blue]
       cs[:json] = [:magenta]
     end
     HighLine.color_scheme = PRETTIES_COLORSCHEME
 
+    # rubocop:disable Style/MethodName: "Use snake_case for method names."
     def self.makeJsonPretty(data, options)
-      if options.pretty then
+      if options.pretty
         ret = JSON.pretty_generate(data).to_s
         ret[0] = HighLine.color(ret[0], :json)
         ret[-1] = HighLine.color(ret[-1], :json)
@@ -31,9 +38,9 @@ module MrMurano
       out += HighLine.color("#{line[:type] || '--'} ".upcase, :subject)
       out += HighLine.color("[#{line[:subject] || ''}]", :subject)
       out += ' '
-      if line.has_key?(:timestamp) then
-        if line[:timestamp].kind_of? Numeric then
-          if options.localtime then
+      if line.key?(:timestamp)
+        if line[:timestamp].is_a? Numeric
+          if options.localtime
             curtime = Time.at(line[:timestamp]).localtime.to_datetime.iso8601(3)
           else
             curtime = Time.at(line[:timestamp]).gmtime.to_datetime.iso8601(3)
@@ -46,11 +53,11 @@ module MrMurano
       end
       out += HighLine.color(curtime, :timestamp)
       out += ":\n"
-      if line.has_key?(:data) then
+      if line.key?(:data)
         data = line[:data]
 
-        if data.kind_of?(Hash) then
-          if data.has_key?(:request) and data.has_key?(:response) then
+        if data.is_a?(Hash)
+          if data.key?(:request) && data.key?(:response)
             out += "---------\nrequest:"
             out += makeJsonPretty(data[:request], options)
 
@@ -71,7 +78,6 @@ module MrMurano
       end
       out
     end
-
   end
 end
-#  vim: set ai et sw=2 ts=2 :
+

--- a/lib/MrMurano/progress.rb
+++ b/lib/MrMurano/progress.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.02 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -32,6 +32,13 @@ module MrMurano
       '▗',
     ].freeze
 
+    EXO_QUADRANTS_7 = [
+      '-',
+      '\\',
+      '|',
+      '/',
+    ].freeze
+
     def whirly_start(msg)
       if $cfg['tool.verbose']
         whirly_pause if @whirly_users > 0
@@ -54,7 +61,7 @@ module MrMurano
 
     def whirly_show
       Whirly.start(
-        spinner: EXO_QUADRANTS,
+        spinner: $cfg['tool.ascii'] && EXO_QUADRANTS_7 || EXO_QUADRANTS,
         status: @whirly_msg,
         append_newline: false,
         #remove_after_stop: false,

--- a/lib/MrMurano/verbosing.rb
+++ b/lib/MrMurano/verbosing.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -149,7 +149,7 @@ module MrMurano
         return true
       end
       confirmed = MrMurano::Verbose.ask_yes_no(
-        "Really delete ‘#{name}’? [y/N] ", false
+        "Really delete #{MrMurano::Verbose.fancy_ticks(name)}? [y/N] ", false
       )
       MrMurano::Verbose.warning(exit_msg) if !confirmed && exit_msg
       if block_given?
@@ -172,16 +172,16 @@ module MrMurano
       MrMurano::Verbose.pluralize?(word, count)
     end
 
-    def self.fancy_tick(string)
-      if $cfg['tool.ascii']
-        "'#{string}'"
+    def self.fancy_ticks(obj)
+      if $cfg.nil? || $cfg['tool.ascii']
+        "'#{obj}'"
       else
-        "‘#{string}’"
+        "‘#{obj}’"
       end
     end
 
-    def fancy_tick(string)
-      MrMurano::Verbose.fancy_tick(string)
+    def fancy_ticks(obj)
+      MrMurano::Verbose.fancy_ticks(obj)
     end
 
     # 2017-07-01: Whirly wrappers. Maybe delete someday

--- a/lib/MrMurano/verbosing.rb
+++ b/lib/MrMurano/verbosing.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.08.22 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -170,6 +170,18 @@ module MrMurano
 
     def pluralize?(word, count)
       MrMurano::Verbose.pluralize?(word, count)
+    end
+
+    def self.fancy_tick(string)
+      if $cfg['tool.ascii']
+        "'#{string}'"
+      else
+        "‘#{string}’"
+      end
+    end
+
+    def fancy_tick(string)
+      MrMurano::Verbose.fancy_tick(string)
     end
 
     # 2017-07-01: Whirly wrappers. Maybe delete someday

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.20 /coding: utf-8
+# Last Modified: 2017.08.23 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -26,7 +26,7 @@ module MrMurano
   #     '3.0.0-beta.2' is changed to '3.0.0.pre.beta.2'
   #   which breaks our build (which expects the version to match herein).
   #   So stick to using the '.pre.X' syntax, which ruby/gems knows.
-  VERSION = '3.0.1.beta.1'
+  VERSION = '3.0.1'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.18 /coding: utf-8
+# Last Modified: 2017.08.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -26,7 +26,7 @@ module MrMurano
   #     '3.0.0-beta.2' is changed to '3.0.0.pre.beta.2'
   #   which breaks our build (which expects the version to match herein).
   #   So stick to using the '.pre.X' syntax, which ruby/gems knows.
-  VERSION = '3.0.0'
+  VERSION = '3.0.1.beta.1'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end

--- a/spec/GatewayDevice_spec.rb
+++ b/spec/GatewayDevice_spec.rb
@@ -1,3 +1,10 @@
+# Last Modified: 2017.08.23 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
 require 'fileutils'
 require 'MrMurano/version'
 require 'MrMurano/Gateway'
@@ -25,31 +32,33 @@ RSpec.describe MrMurano::Gateway::Device do
   context "listing" do
     it "lists" do
       body = {
-        :mayLoadMore=>false,
-        :devices=>
-        [{:identity=>"58",
-          :auth=>{:type=>"cik"},
-          :state=>{},
-          :locked=>false,
-          :reprovision=>false,
-          :devmode=>false,
-          :lastip=>"",
-          :lastseen=>1487021743864000,
-          :status=>"provisioned",
-          :online=>false},
-         {:identity=>"56",
-          :auth=>{:type=>"cik"},
-          :state=>{},
-          :locked=>false,
-          :reprovision=>false,
-          :devmode=>false,
-          :lastip=>"",
-          :lastseen=>1487021650584000,
-          :status=>"provisioned",
-          :online=>false},
+        mayLoadMore: false,
+        devices:
+        [{identity: "58",
+          auth: {type: "cik"},
+          state: {},
+          locked: false,
+          reprovision: false,
+          devmode: false,
+          lastip: "",
+          lastseen: 1487021743864000,
+          status: "provisioned",
+          online: false},
+         {identity: "56",
+          auth: {type: "cik"},
+          state: {},
+          locked: false,
+          reprovision: false,
+          devmode: false,
+          lastip: "",
+          lastseen: 1487021650584000,
+          status: "provisioned",
+          online: false},
         ]}
-       stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/").
-         to_return(:body=>body.to_json)
+       stub_request(
+         :get,
+         "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/"
+       ).to_return(body: body.to_json)
 
       ret = @gw.list
       expect(ret).to eq(body)
@@ -57,22 +66,24 @@ RSpec.describe MrMurano::Gateway::Device do
 
     it "lists with limit" do
       body = {
-        :mayLoadMore=>false,
-        :devices=>
-        [{:identity=>"58",
-          :auth=>{:type=>"cik"},
-          :state=>{},
-          :locked=>false,
-          :reprovision=>false,
-          :devmode=>false,
-          :lastip=>"",
-          :lastseen=>1487021743864000,
-          :status=>"provisioned",
-          :online=>false},
+        mayLoadMore: false,
+        devices:
+        [{identity: "58",
+          auth: {type: "cik"},
+          state: {},
+          locked: false,
+          reprovision: false,
+          devmode: false,
+          lastip: "",
+          lastseen: 1487021743864000,
+          status: "provisioned",
+          online: false},
         ]}
-       stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/").
-         with(:query=>{:limit=>'1'}).
-         to_return(:body=>body.to_json)
+       stub_request(
+         :get,
+         "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/"
+       ).with(query: {limit: '1'}
+       ).to_return(body: body.to_json)
 
       ret = @gw.list(1)
       expect(ret).to eq(body)
@@ -80,22 +91,24 @@ RSpec.describe MrMurano::Gateway::Device do
 
     it "lists with before" do
       body = {
-        :mayLoadMore=>false,
-        :devices=>
-        [{:identity=>"58",
-          :auth=>{:type=>"cik"},
-          :state=>{},
-          :locked=>false,
-          :reprovision=>false,
-          :devmode=>false,
-          :lastip=>"",
-          :lastseen=>1487021743864000,
-          :status=>"provisioned",
-          :online=>false},
+        mayLoadMore: false,
+        devices:
+        [{identity: "58",
+          auth: {type: "cik"},
+          state: {},
+          locked: false,
+          reprovision: false,
+          devmode: false,
+          lastip: "",
+          lastseen: 1487021743864000,
+          status: "provisioned",
+          online: false},
         ]}
-       stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/").
-         with(:query=>{:limit=>'1', :before=>'1487021743864000'}).
-         to_return(:body=>body.to_json)
+       stub_request(
+         :get,
+         "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/"
+       ).with(query: { limit: '1', before: '1487021743864000' }
+       ).to_return(body: body.to_json)
 
       ret = @gw.list(1, 1487021743864000)
       expect(ret).to eq(body)
@@ -104,18 +117,20 @@ RSpec.describe MrMurano::Gateway::Device do
 
   it "fetches one" do
     body = {
-      :identity=>"58",
-      :auth=>{:type=>"cik"},
-      :state=>{},
-      :locked=>false,
-      :reprovision=>false,
-      :devmode=>false,
-      :lastip=>"",
-      :lastseen=>1487021743864000,
-      :status=>"provisioned",
-      :online=>false}
-    stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58").
-      to_return(:body=>body.to_json)
+      identity: "58",
+      auth: {type: "cik"},
+      state: {},
+      locked: false,
+      reprovision: false,
+      devmode: false,
+      lastip: "",
+      lastseen: 1487021743864000,
+      status: "provisioned",
+      online: false}
+    stub_request(
+      :get,
+      "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58"
+    ).to_return(body: body.to_json)
 
     ret = @gw.fetch(58)
     expect(ret).to eq(body)
@@ -123,18 +138,20 @@ RSpec.describe MrMurano::Gateway::Device do
 
   it "enables one" do
     body = {
-      :identity=>"58",
-      :auth=>{:type=>"cik"},
-      :state=>{},
-      :locked=>false,
-      :reprovision=>false,
-      :devmode=>false,
-      :lastip=>"",
-      :lastseen=>1487021743864000,
-      :status=>"provisioned",
-      :online=>false}
-    stub_request(:put, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58").
-      to_return(:body=>body.to_json)
+      identity: "58",
+      auth: {type: "cik"},
+      state: {},
+      locked: false,
+      reprovision: false,
+      devmode: false,
+      lastip: "",
+      lastseen: 1487021743864000,
+      status: "provisioned",
+      online: false}
+    stub_request(
+      :put,
+      "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58"
+    ).to_return(body: body.to_json)
 
     ret = @gw.enable(58)
     expect(ret).to eq(body)
@@ -142,58 +159,64 @@ RSpec.describe MrMurano::Gateway::Device do
 
   it "enables with options" do
     body = {
-      :identity=>"58",
-      :auth=>{:type=>"cik"},
-      :state=>{},
-      :locked=>false,
-      :reprovision=>false,
-      :devmode=>false,
-      :lastip=>"",
-      :lastseen=>1487021743864000,
-      :status=>"provisioned",
-      :online=>false}
-    stub_request(:put, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58").
-      with(:body=>{:type=>:certificate,:expire=>123456}.to_json).
-      to_return(:body=>body.to_json)
+      identity: "58",
+      auth: {type: "cik"},
+      state: {},
+      locked: false,
+      reprovision: false,
+      devmode: false,
+      lastip: "",
+      lastseen: 1487021743864000,
+      status: "provisioned",
+      online: false}
+    stub_request(
+      :put,
+      "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58"
+    ). with(body: { auth: { expire: 123456, type: :certificate }, locked: false }.to_json
+    ).to_return(body: body.to_json)
 
-    ret = @gw.enable(58, :type=>:certificate, :expire=>123456)
+    ret = @gw.enable(58, type: :certificate, expire: '123456')
     expect(ret).to eq(body)
   end
 
   it "enables with extra options" do
     body = {
-      :identity=>"58",
-      :auth=>{:type=>"cik"},
-      :state=>{},
-      :locked=>false,
-      :reprovision=>false,
-      :devmode=>false,
-      :lastip=>"",
-      :lastseen=>1487021743864000,
-      :status=>"provisioned",
-      :online=>false}
-    stub_request(:put, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58").
-      with(:body=>{:type=>:certificate,:expire=>123456}.to_json).
-      to_return(:body=>body.to_json)
+      identity: "58",
+      auth: {type: "cik"},
+      state: {},
+      locked: false,
+      reprovision: false,
+      devmode: false,
+      lastip: "",
+      lastseen: 1487021743864000,
+      status: "provisioned",
+      online: false}
+    stub_request(
+      :put,
+      "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58"
+    ).with(body: {auth: { expire: 123456, type: :certificate }, locked: false }.to_json
+    ).to_return(body: body.to_json)
 
-    ret = @gw.enable(58, :go=>:blueteam, :type=>:certificate, :expire=>123456, :bob=>:built)
+    ret = @gw.enable(58, go: :blueteam, type: :certificate, expire: 123456, bob: :built)
     expect(ret).to eq(body)
   end
 
   it "removes one" do
     body = {
-      :identity=>"58",
-      :auth=>{:type=>"cik"},
-      :state=>{},
-      :locked=>false,
-      :reprovision=>false,
-      :devmode=>false,
-      :lastip=>"",
-      :lastseen=>1487021743864000,
-      :status=>"provisioned",
-      :online=>false}
-    stub_request(:delete, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58").
-      to_return(:body=>body.to_json)
+      identity: "58",
+      auth: {type: "cik"},
+      state: {},
+      locked: false,
+      reprovision: false,
+      devmode: false,
+      lastip: "",
+      lastseen: 1487021743864000,
+      status: "provisioned",
+      online: false}
+    stub_request(
+      :delete,
+      "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/58"
+    ).to_return(body: body.to_json)
 
     ret = @gw.remove(58)
     expect(ret).to eq(body)
@@ -205,20 +228,26 @@ RSpec.describe MrMurano::Gateway::Device do
       allow(@bgw).to receive(:token).and_return("TTTTTTTTTT")
       expect(MrMurano::Gateway::GweBase).to receive(:new).and_return(@bgw)
       allow(@gw).to receive(:token).and_return("TTTTTTTTTT")
-      stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2").
-        to_return(:body=>{:fqdn=>"xxxxx.m2.exosite-staging.io"}.to_json)
+      stub_request(
+        :get,
+        "https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2"
+      ).to_return(body: { fqdn: "xxxxx.m2.exosite-staging.io" }.to_json)
     end
     it "succeeds" do
-      stub_request(:post, "https://xxxxx.m2.exosite-staging.io/provision/activate").
-        to_return(:body=>'XXXXXXXX')
+      stub_request(
+        :post,
+        "https://xxxxx.m2.exosite-staging.io/provision/activate"
+      ).to_return(body: 'XXXXXXXX')
 
       ret = @gw.activate(58)
       expect(ret).to eq('XXXXXXXX')
     end
 
     it "was already activated" do
-      stub_request(:post, "https://xxxxx.m2.exosite-staging.io/provision/activate").
-        to_return(:status => 409)
+      stub_request(
+        :post,
+        "https://xxxxx.m2.exosite-staging.io/provision/activate"
+      ).to_return(status: 409)
 
       saved = $stderr
       $stderr = StringIO.new
@@ -232,8 +261,10 @@ RSpec.describe MrMurano::Gateway::Device do
     end
 
     it "wasn't enabled" do
-      stub_request(:post, "https://xxxxx.m2.exosite-staging.io/provision/activate").
-        to_return(:status => 404)
+      stub_request(
+        :post,
+        "https://xxxxx.m2.exosite-staging.io/provision/activate"
+      ).to_return(status: 404)
 
       saved = $stderr
       $stderr = StringIO.new
@@ -247,8 +278,10 @@ RSpec.describe MrMurano::Gateway::Device do
   context "enables batch" do
     it "enables from cvs" do
       File.open('ids.csv', 'w') {|io| io << "ID\n1\n2\n3\n4\n5"}
-      stub_request(:post, 'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identities').
-        with(:headers=>{'Content-Type'=>%r{^multipart/form-data.*}}) do |request|
+      stub_request(
+        :post,
+        'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identities'
+      ).with(headers: { 'Content-Type' => %r{^multipart/form-data.*} }) do |request|
           request.body.to_s =~ %r{Content-Type: text/csv\r\n\r\nID\r?\n1\r?\n2\r?\n3\r?\n4\r?\n5}
       end
       @gw.enable_batch('ids.csv')
@@ -260,8 +293,10 @@ RSpec.describe MrMurano::Gateway::Device do
 
     it "but file is not text" do
       File.open('ids.csv', 'wb') {|io| io << "\0\0\0\0"}
-      stub_request(:post, 'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identities').
-        to_return(:status=>400, :body => "CSV file format invalid")
+      stub_request(
+        :post,
+        'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identities'
+      ).to_return(status: 400, body: "CSV file format invalid")
       saved = $stderr
       $stderr = StringIO.new
       @gw.enable_batch('ids.csv')
@@ -271,10 +306,12 @@ RSpec.describe MrMurano::Gateway::Device do
 
     it "but file is missing header" do
       File.open('ids.csv', 'w') {|io| io << "1\n2\n3\n4\n5"}
-      stub_request(:post, 'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identities').
-        with(:headers=>{'Content-Type'=>%r{^multipart/form-data.*}}) do |request|
+      stub_request(
+        :post,
+        'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identities'
+      ).with(headers: { 'Content-Type' => %r{^multipart/form-data.*} }) do |request|
           request.body.to_s =~ %r{Content-Type: text/csv\r\n\r\n1\r?\n2\r?\n3\r?\n4\r?\n5}
-      end.to_return(:status=>400, :body => "CSV file format invalid")
+      end.to_return(status: 400, body: "CSV file format invalid")
       saved = $stderr
       $stderr = StringIO.new
       @gw.enable_batch('ids.csv')
@@ -284,9 +321,11 @@ RSpec.describe MrMurano::Gateway::Device do
   end
 
   it "reads state" do
-    body = {:bob=>{:reported=>"9", :set=>"9", :timestamp=>1487021046160363}}
-    stub_request(:get, 'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/56/state').
-      to_return(:body=>body.to_json)
+    body = {bob: {reported: "9", set: "9", timestamp: 1487021046160363}}
+    stub_request(
+      :get,
+      'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/56/state'
+    ).to_return(body: body.to_json)
 
     ret = @gw.read(56)
     expect(ret).to eq(body)
@@ -294,28 +333,30 @@ RSpec.describe MrMurano::Gateway::Device do
 
   context "writes state" do
     it "succeeds" do
-      body = {:bob=>"fuzz"}
-      stub_request(:patch, 'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/56/state').
-        with(:body=>body.to_json)
+      body = {bob: "fuzz"}
+      stub_request(
+        :patch,
+        'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/56/state'
+      ).with(body: body.to_json)
 
-      @gw.write(56, :bob=>'fuzz')
+      @gw.write(56, bob: 'fuzz')
     end
 
     it "fails" do
-      body = {:bob=>"fuzz"}
-      stub_request(:patch, 'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/56/state').
-        with(:body=>body.to_json).
-        to_return(:status=> 400, :body => 'Value is not settable')
+      body = {bob: "fuzz"}
+      stub_request(
+        :patch,
+        'https://bizapi.hosted.exosite.io/api:1/service/XYZ/device2/identity/56/state'
+      ).with(body: body.to_json
+      ).to_return(status: 400, body: 'Value is not settable')
 
       saved = $stderr
       $stderr = StringIO.new
 
-      @gw.write(56, :bob=>'fuzz')
+      @gw.write(56, bob: 'fuzz')
       expect($stderr.string).to eq("\e[31mRequest Failed: 400: Value is not settable\e[0m\n")
       $stderr = saved
     end
   end
-
 end
 
-#  vim: set ai et sw=2 ts=2 :

--- a/spec/Mock_spec.rb
+++ b/spec/Mock_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MrMurano::Mock, "#mock" do
   it "can create the testpoint file" do
       uuid = @mock.create_testpoint()
       expect(uuid.length).to be("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".length)
-      path = @mock.get_testpoint_path()
+      path = @mock.testpoint_path()
       testpoint = File.read(path)
       expect(testpoint.include? uuid).to be(true)
   end
@@ -29,14 +29,14 @@ RSpec.describe MrMurano::Mock, "#mock" do
 
   it "can remove the testpoint file" do
       @mock.create_testpoint()
-      path = @mock.get_testpoint_path()
+      path = @mock.testpoint_path()
       removed = @mock.remove_testpoint()
       expect(removed).to be(true)
       expect(File.exist?(path)).to be(false)
   end
 
   it "can remove the missing testpoint file" do
-      path = @mock.get_testpoint_path()
+      path = @mock.testpoint_path()
       removed = @mock.remove_testpoint()
       expect(removed).to be(false)
       expect(File.exist?(path)).to be(false)

--- a/spec/Solution-ServiceEventHandler_spec.rb
+++ b/spec/Solution-ServiceEventHandler_spec.rb
@@ -1,3 +1,10 @@
+# Last Modified: 2017.08.22 /coding: utf-8
+# frozen_string_literal: true
+
+# Copyright © 2016-2017 Exosite LLC.
+# License: MIT. See LICENSE.txt.
+#  vim:tw=0:ts=2:sw=2:et:ai
+
 require 'tempfile'
 require 'MrMurano/version'
 require 'MrMurano/ProjectFile'
@@ -30,94 +37,105 @@ RSpec.describe MrMurano::EventHandler do
   end
 
   it "lists" do
-    body = {:items=>[{:id=>"9K0",
-             :name=>"debug",
-             :alias=>"XYZ_debug",
-             :solution_id=>"XYZ",
-             :service=>"device",
-             :event=>"datapoint",
-             :created_at=>"2016-07-07T19:16:19.479Z",
-             :updated_at=>"2016-09-12T13:26:55.868Z"}],
-            :total=>1}
+    body = {
+      items: [
+        {
+          id: "9K0",
+          name: "debug",
+          alias: "XYZ_debug",
+          solution_id: "XYZ",
+          service: "device",
+          event: "datapoint",
+          created_at: "2016-07-07T19:16:19.479Z",
+          updated_at: "2016-09-12T13:26:55.868Z",
+        },
+      ],
+      total: 1,
+    }
     stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(body: body.to_json)
-
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(body: body.to_json)
     ret = @srv.list
     expect(ret).to eq(body[:items])
   end
 
   it "fetches, with header" do
-    body = {:id=>"9K0",
-             :name=>"debug",
-             :alias=>"XYZ_debug",
-             :solution_id=>"XYZ",
-             :service=>"device",
-             :event=>"datapoint",
-             :created_at=>"2016-07-07T19:16:19.479Z",
-             :updated_at=>"2016-09-12T13:26:55.868Z",
-             :script=>%{--#EVENT device datapoint
-             -- lua code is here
-    function foo(bar)
-      return bar + 1
-    end
-    }
+    body = {
+      id: "9K0",
+      name: "debug",
+      alias: "XYZ_debug",
+      solution_id: "XYZ",
+      service: "device",
+      event: "datapoint",
+      created_at: "2016-07-07T19:16:19.479Z",
+      updated_at: "2016-09-12T13:26:55.868Z",
+      script: %{--#EVENT device datapoint
+-- lua code is here
+function foo(bar)
+  return bar + 1
+end
+      },
     }
     stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler/9K0").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(body: body.to_json)
-
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(body: body.to_json)
     ret = @srv.fetch('9K0')
     expect(ret).to eq(body[:script])
   end
 
   it "fetches, with header into block" do
-    body = {:id=>"9K0",
-             :name=>"debug",
-             :alias=>"XYZ_debug",
-             :solution_id=>"XYZ",
-             :service=>"device",
-             :event=>"datapoint",
-             :created_at=>"2016-07-07T19:16:19.479Z",
-             :updated_at=>"2016-09-12T13:26:55.868Z",
-             :script=>%{--#EVENT device datapoint
-             -- lua code is here
-    function foo(bar)
-      return bar + 1
-    end
-    }
+    body = {
+      id: "9K0",
+      name: "debug",
+      alias: "XYZ_debug",
+      solution_id: "XYZ",
+      service: "device",
+      event: "datapoint",
+      created_at: "2016-07-07T19:16:19.479Z",
+      updated_at: "2016-09-12T13:26:55.868Z",
+      script: %{
+        --#EVENT device datapoint
+        -- lua code is here
+        function foo(bar)
+          return bar + 1
+        end
+      },
     }
     stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler/9K0").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(body: body.to_json)
-
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(body: body.to_json)
     ret = nil
     @srv.fetch('9K0') { |sc| ret = sc }
     expect(ret).to eq(body[:script])
   end
 
   it "fetches, without header" do
-    body = {:id=>"9K0",
-             :name=>"debug",
-             :alias=>"XYZ_debug",
-             :solution_id=>"XYZ",
-             :service=>"device",
-             :event=>"datapoint",
-             :created_at=>"2016-07-07T19:16:19.479Z",
-             :updated_at=>"2016-09-12T13:26:55.868Z",
-             :script=>%{-- lua code is here
+    body = {
+      id: "9K0",
+      name: "debug",
+      alias: "XYZ_debug",
+      solution_id: "XYZ",
+      service: "device",
+      event: "datapoint",
+      created_at: "2016-07-07T19:16:19.479Z",
+      updated_at: "2016-09-12T13:26:55.868Z",
+      script: %{-- lua code is here
 function foo(bar)
   return bar + 1
 end
-}
+},
     }
     stub_request(:get, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler/9K0").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(body: body.to_json)
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(body: body.to_json)
 
     ret = @srv.fetch('9K0')
     expect(ret).to eq(%{--#EVENT device datapoint
@@ -130,9 +148,10 @@ end
 
   it "removes" do
     stub_request(:delete, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler/9K0").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(body: "")
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(body: "")
 
     ret = @srv.remove('9K0')
     expect(ret).to eq({})
@@ -140,24 +159,26 @@ end
 
   it "uploads over old version" do
     stub_request(:put, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler/XYZ_data_datapoint").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(body: "")
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(body: "")
 
     Tempfile.open('foo') do |tio|
-      tio << %{-- lua code is here
-    function foo(bar)
-      return bar + 1
-    end
+      tio << %{
+        -- lua code is here
+        function foo(bar)
+          return bar + 1
+        end
       }
       tio.close
 
       ret = @srv.upload(tio.path,
         MrMurano::EventHandler::EventHandlerItem.new(
-          :id=>"9K0",
-          :service=>'data',
-          :event=>'datapoint',
-          :solution_id=>"XYZ",
+          id: "9K0",
+          service: 'data',
+          event: 'datapoint',
+          solution_id: "XYZ",
       ))
       expect(ret)
     end
@@ -165,28 +186,31 @@ end
 
   it "uploads when nothing is there" do
     stub_request(:put, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler/XYZ_device_datapoint").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(status: 404)
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(status: 404)
     stub_request(:post, "https://bizapi.hosted.exosite.io/api:1/solution/XYZ/eventhandler/").
-      with(:headers=>{'Authorization'=>'token TTTTTTTTTT',
-                      'Content-Type'=>'application/json'}).
-      to_return(body: "")
+      with(headers: {
+        'Authorization'=>'token TTTTTTTTTT',
+        'Content-Type'=>'application/json',
+      }).to_return(body: "")
 
     Tempfile.open('foo') do |tio|
-      tio << %{-- lua code is here
-    function foo(bar)
-      return bar + 1
-    end
+      tio << %{
+        -- lua code is here
+        function foo(bar)
+          return bar + 1
+        end
       }
       tio.close
 
       ret = @srv.upload(tio.path,
         MrMurano::EventHandler::EventHandlerItem.new(
-          :id=>"9K0",
-          :service=>'device',
-          :event=>'datapoint',
-          :solution_id=>"XYZ",
+          id: "9K0",
+          service: 'device',
+          event: 'datapoint',
+          solution_id: "XYZ",
       ))
       expect(ret)
     end
@@ -195,22 +219,26 @@ end
 
   context "compares" do
     before(:example) do
-      @iA = {:id=>"9K0",
-            :name=>"debug",
-            :alias=>"XYZ_debug",
-            :solution_id=>"XYZ",
-             :service=>"device",
-             :event=>"datapoint",
-            :created_at=>"2016-07-07T19:16:19.479Z",
-            :updated_at=>"2016-09-12T13:26:55.868Z"}
-      @iB = {:id=>"9K0",
-            :name=>"debug",
-            :alias=>"XYZ_debug",
-            :solution_id=>"XYZ",
-             :service=>"device",
-             :event=>"datapoint",
-            :created_at=>"2016-07-07T19:16:19.479Z",
-            :updated_at=>"2016-09-12T13:26:55.868Z"}
+      @iA = {
+        id: "9K0",
+        name: "debug",
+        alias: "XYZ_debug",
+        solution_id: "XYZ",
+        service: "device",
+        event: "datapoint",
+        created_at: "2016-07-07T19:16:19.479Z",
+        updated_at: "2016-09-12T13:26:55.868Z",
+      }
+      @iB = {
+        id: "9K0",
+        name: "debug",
+        alias: "XYZ_debug",
+        solution_id: "XYZ",
+        service: "device",
+        event: "datapoint",
+        created_at: "2016-07-07T19:16:19.479Z",
+        updated_at: "2016-09-12T13:26:55.868Z",
+      }
     end
     it "both have updated_at" do
       ret = @srv.docmp(@iA, @iB)
@@ -221,13 +249,13 @@ end
       Tempfile.open('foo') do |tio|
         tio << "something"
         tio.close
-        iA = @iA.reject{|k,v| k == :updated_at}.merge({
-          :local_path => Pathname.new(tio.path)
+        iA = @iA.reject { |k, _v| k == :updated_at }.merge({
+          local_path: Pathname.new(tio.path),
         })
         ret = @srv.docmp(iA, @iB)
         expect(ret).to eq(true)
 
-        iB = @iB.merge({:updated_at=>Pathname.new(tio.path).mtime.getutc})
+        iB = @iB.merge( { updated_at: Pathname.new(tio.path).mtime.getutc })
         ret = @srv.docmp(iA, iB)
         expect(ret).to eq(false)
       end
@@ -237,13 +265,13 @@ end
       Tempfile.open('foo') do |tio|
         tio << "something"
         tio.close
-        iB = @iB.reject{|k,v| k == :updated_at}.merge({
-          :local_path => Pathname.new(tio.path)
+        iB = @iB.reject{ |k, _v| k == :updated_at }.merge({
+          local_path: Pathname.new(tio.path),
         })
         ret = @srv.docmp(@iA, iB)
         expect(ret).to eq(true)
 
-        iA = @iA.merge({:updated_at=>Pathname.new(tio.path).mtime.getutc})
+        iA = @iA.merge({ updated_at: Pathname.new(tio.path).mtime.getutc })
         ret = @srv.docmp(iA, iB)
         expect(ret).to eq(false)
       end
@@ -252,12 +280,12 @@ end
 
   context "Lookup functions" do
     it "gets local name" do
-      ret = @srv.tolocalname({ :name=>"bob" }, nil)
+      ret = @srv.tolocalname({ name: "bob" }, nil)
       expect(ret).to eq('bob.lua')
     end
 
     it "gets synckey" do
-      ret = @srv.synckey({ :service=>'device', :event=>'datapoint' })
+      ret = @srv.synckey({ service: 'device', event: 'datapoint' })
       expect(ret).to eq("device_datapoint")
     end
 
@@ -275,25 +303,25 @@ end
 
     it "raises on alias without service" do
       expect {
-        @srv.mkname(MrMurano::EventHandler::EventHandlerItem.new(:event=>'bob'))
+        @srv.mkname(MrMurano::EventHandler::EventHandlerItem.new(event: 'bob'))
       }.to raise_error %{Missing parts! {"event":"bob"}}
     end
 
     it "raises on alias without event" do
       expect {
-        @srv.mkalias(MrMurano::EventHandler::EventHandlerItem.new(:service=>'bob'))
+        @srv.mkalias(MrMurano::EventHandler::EventHandlerItem.new(service: 'bob'))
       }.to raise_error %{Missing parts! {"service":"bob"}}
     end
 
     it "raises on name without service" do
       expect {
-        @srv.mkalias(MrMurano::EventHandler::EventHandlerItem.new(:event=>'bob'))
+        @srv.mkalias(MrMurano::EventHandler::EventHandlerItem.new(event: 'bob'))
       }.to raise_error %{Missing parts! {"event":"bob"}}
     end
 
     it "raises on name without event" do
       expect {
-        @srv.mkname(MrMurano::EventHandler::EventHandlerItem.new(:service=>'bob'))
+        @srv.mkname(MrMurano::EventHandler::EventHandlerItem.new(service: 'bob'))
       }.to raise_error %{Missing parts! {"service":"bob"}}
     end
   end
@@ -312,14 +340,18 @@ end
         tio.close
 
         ret = @srv.to_remote_item(nil, tio.path)
-        expect(ret).to eq({:service=>'device',
-                           :event=>'datapoint',
-                           :type=>nil,
-                           :line=>0,
-                           :line_end=>3,
-                           :local_path=>Pathname.new(tio.path),
-                           :script=>%{--#EVENT device datapoint\n-- do something.\nTsdb.write{tags={sn='1'},metrics={[data.alias]=data.value[2]}}\n},
-        })
+        expect(ret).to eq(
+          {
+            service: 'device',
+            event: 'datapoint',
+            svc_alias: nil,
+            type: nil,
+            line: 0,
+            line_end: 3,
+            local_path: Pathname.new(tio.path),
+            script: %{--#EVENT device datapoint\n-- do something.\nTsdb.write{tags={sn='1'},metrics={[data.alias]=data.value[2]}}\n},
+          }
+        )
       end
     end
 
@@ -348,13 +380,14 @@ end
         ret = @srv.to_remote_item(nil, tio.path)
         expect(ret).to eq(
           MrMurano::EventHandler::EventHandlerItem.new(
-            :service=>'device',
-            :event=>'datapoint',
-            :type=>nil,
-            :line=>1,
-            :line_end=>3,
-            :local_path=>Pathname.new(tio.path),
-            :script=>%{--#EVENT device datapoint\nTsdb.write{tags={sn='1'},metrics={[data.alias]=data.value[2]}}\n},
+            service: 'device',
+            event: 'datapoint',
+            svc_alias: nil,
+            type: nil,
+            line: 1,
+            line_end: 3,
+            local_path: Pathname.new(tio.path),
+            script: %{--#EVENT device datapoint\nTsdb.write{tags={sn='1'},metrics={[data.alias]=data.value[2]}}\n},
           ))
       end
     end
@@ -364,9 +397,9 @@ end
   context "Matching" do
     before(:example) do
       @an_item = {
-        :service=>'bob',
-        :event=>'built',
-        :local_path=>Pathname.new('a/relative/path.lua'),
+        service: 'bob',
+        event: 'built',
+        local_path: Pathname.new('a/relative/path.lua'),
       }
     end
     context "service" do
@@ -397,4 +430,4 @@ end
     end
   end
 end
-#  vim: set ai et sw=2 ts=2 :
+

--- a/spec/SyncUpDown_spec.rb
+++ b/spec/SyncUpDown_spec.rb
@@ -64,46 +64,51 @@ RSpec.describe MrMurano::SyncUpDown do
       t = TSUD.new
       expect(t).to receive(:warning).once.with(/Skipping missing location.*/)
       ret = t.status
-      expect(ret).to eq({toadd: [], todel: [], tomod: [], unchg: [], skipd: []})
+      expect(ret).to eq(
+        { toadd: [], todel: [], tomod: [], unchg: [], skipd: [], clash: [] }
+      )
     end
 
     it "finds nothing in empty directory" do
       FileUtils.mkpath(@project_dir + '/tsud')
       t = TSUD.new
       ret = t.status
-      expect(ret).to eq({toadd: [], todel: [], tomod: [], unchg: [], skipd: []})
+      expect(ret).to eq(
+        { toadd: [], todel: [], tomod: [], unchg: [], skipd: [], clash: [] }
+      )
     end
 
     it "finds things there but not here" do
       FileUtils.mkpath(@project_dir + '/tsud')
       t = TSUD.new
       expect(t).to receive(:list).once.and_return([
-        {:name=>1},
-        {:name=>2},
-        {:name=>3},
+        {name: 1},
+        {name: 2},
+        {name: 3},
       ])
       ret = t.status
       expect(ret).to eq({
-        :toadd=>[],
-        :todel=>[
+        toadd: [],
+        todel: [
           {
-            :name=>1,
-            :synckey=>1,
-            :synctype=>TSUD.description,
+            name: 1,
+            synckey: 1,
+            synctype: TSUD.description,
           },
           {
-            :name=>2,
-            :synckey=>2,
-            :synctype=>TSUD.description,
+            name: 2,
+            synckey: 2,
+            synctype: TSUD.description,
           },
           {
-            :name=>3,
-            :synckey=>3,
-            :synctype=>TSUD.description,
+            name: 3,
+            synckey: 3,
+            synctype: TSUD.description,
           }],
-        :tomod=>[],
-        :unchg=>[],
-        :skipd=>[],
+        tomod: [],
+        unchg: [],
+        skipd: [],
+        clash: [],
       })
     end
 
@@ -111,11 +116,11 @@ RSpec.describe MrMurano::SyncUpDown do
       FileUtils.mkpath(@project_dir + '/tsud')
       t = TSUD.new
       expect(t).to receive(:list).once.and_return([
-        {:name=>1},
-        {:name=>2},
-        {:name=>3},
+        {name: 1},
+        {name: 2},
+        {name: 3},
       ])
-      ret = t.status({:asdown=>true})
+      ret = t.status({asdown: true})
       expect(ret).to eq({
         todel: [],
         toadd: [
@@ -126,6 +131,7 @@ RSpec.describe MrMurano::SyncUpDown do
         tomod: [],
         unchg: [],
         skipd: [],
+        clash: [],
       })
     end
 
@@ -135,8 +141,8 @@ RSpec.describe MrMurano::SyncUpDown do
       FileUtils.touch(@project_dir + '/tsud/two.lua')
       t = TSUD.new
       expect(t).to receive(:to_remote_item).and_return(
-        {:name=>'one.lua'},
-        {:name=>'two.lua'},
+        {name: 'one.lua'},
+        {name: 'two.lua'},
       )
       ret = t.status
       expect(ret).to match({
@@ -158,6 +164,7 @@ RSpec.describe MrMurano::SyncUpDown do
         tomod: [],
         unchg: [],
         skipd: [],
+        clash: [],
       })
     end
 
@@ -167,12 +174,12 @@ RSpec.describe MrMurano::SyncUpDown do
       FileUtils.touch(@project_dir + '/tsud/two.lua')
       t = TSUD.new
       expect(t).to receive(:list).once.and_return([
-        {:name=>'one.lua'},
-        {:name=>'two.lua'},
+        {name: 'one.lua'},
+        {name: 'two.lua'},
       ])
       expect(t).to receive(:to_remote_item).and_return(
-        {:name=>'one.lua'},
-        {:name=>'two.lua'},
+        {name: 'one.lua'},
+        {name: 'two.lua'},
       )
       ret = t.status
       expect(ret).to match({
@@ -194,6 +201,7 @@ RSpec.describe MrMurano::SyncUpDown do
         toadd: [],
         unchg: [],
         skipd: [],
+        clash: [],
       })
     end
     it "finds things here and there; but they're the same" do
@@ -202,12 +210,12 @@ RSpec.describe MrMurano::SyncUpDown do
       FileUtils.touch(@project_dir + '/tsud/two.lua')
       t = TSUD.new
       expect(t).to receive(:list).once.and_return([
-        {:name=>'one.lua'},
-        {:name=>'two.lua'},
+        {name: 'one.lua'},
+        {name: 'two.lua'},
       ])
       expect(t).to receive(:to_remote_item).and_return(
-        {:name=>'one.lua'},
-        {:name=>'two.lua'},
+        {name: 'one.lua'},
+        {name: 'two.lua'},
       )
       expect(t).to receive(:docmp).twice.and_return(false)
       ret = t.status
@@ -230,6 +238,7 @@ RSpec.describe MrMurano::SyncUpDown do
         toadd: [],
         tomod: [],
         skipd: [],
+        clash: [],
       })
     end
 
@@ -238,13 +247,13 @@ RSpec.describe MrMurano::SyncUpDown do
       FileUtils.touch(@project_dir + '/tsud/one.lua')
       t = TSUD.new
       expect(t).to receive(:list).once.and_return([
-        {:name=>'one.lua'}
+        {name: 'one.lua'}
       ])
       expect(t).to receive(:to_remote_item).and_return(
-        {:name=>'one.lua'}
+        {name: 'one.lua'}
       )
       expect(t).to receive(:dodiff).once.and_return("diffed output")
-      ret = t.status({:diff=>true})
+      ret = t.status({diff: true})
       expect(ret).to match({
         tomod: [
           {
@@ -259,6 +268,7 @@ RSpec.describe MrMurano::SyncUpDown do
         toadd: [],
         unchg: [],
         skipd: [],
+        clash: [],
       })
     end
 
@@ -274,209 +284,213 @@ RSpec.describe MrMurano::SyncUpDown do
         FileUtils.touch(@project_dir + '/tsud/ga/six.lua')  # toadd
         @t = TSUD.new
         expect(@t).to receive(:list).once.and_return([
-          MrMurano::SyncUpDown::Item.new({:name=>'eight.lua', :updated_at=>ITEM_UPDATED_AT}), # todel
-          MrMurano::SyncUpDown::Item.new({:name=>'four.lua', :updated_at=>ITEM_UPDATED_AT}),  # unchg
-          MrMurano::SyncUpDown::Item.new({:name=>'one.lua', :updated_at=>ITEM_UPDATED_AT}),   # tomod
-          MrMurano::SyncUpDown::Item.new({:name=>'seven.lua', :updated_at=>ITEM_UPDATED_AT}), # todel
-          MrMurano::SyncUpDown::Item.new({:name=>'three.lua', :updated_at=>ITEM_UPDATED_AT}), # unchg
-          MrMurano::SyncUpDown::Item.new({:name=>'two.lua', :updated_at=>ITEM_UPDATED_AT}),   # tomod
+          MrMurano::SyncUpDown::Item.new({name: 'eight.lua', updated_at: ITEM_UPDATED_AT}), # todel
+          MrMurano::SyncUpDown::Item.new({name: 'four.lua', updated_at: ITEM_UPDATED_AT}),  # unchg
+          MrMurano::SyncUpDown::Item.new({name: 'one.lua', updated_at: ITEM_UPDATED_AT}),   # tomod
+          MrMurano::SyncUpDown::Item.new({name: 'seven.lua', updated_at: ITEM_UPDATED_AT}), # todel
+          MrMurano::SyncUpDown::Item.new({name: 'three.lua', updated_at: ITEM_UPDATED_AT}), # unchg
+          MrMurano::SyncUpDown::Item.new({name: 'two.lua', updated_at: ITEM_UPDATED_AT}),   # tomod
         ])
         expect(@t).to receive(:to_remote_item).
           with(anything(), pathname_globs('**/one.lua')).
-          and_return(MrMurano::SyncUpDown::Item.new({:name=>'one.lua', :updated_at=>ITEM_UPDATED_AT}))
+          and_return(MrMurano::SyncUpDown::Item.new({name: 'one.lua', updated_at: ITEM_UPDATED_AT}))
         expect(@t).to receive(:to_remote_item).
           with(anything(), pathname_globs('**/two.lua')).
-          and_return(MrMurano::SyncUpDown::Item.new({:name=>'two.lua', :updated_at=>ITEM_UPDATED_AT}))
+          and_return(MrMurano::SyncUpDown::Item.new({name: 'two.lua', updated_at: ITEM_UPDATED_AT}))
         expect(@t).to receive(:to_remote_item).
           with(anything(), pathname_globs('**/three.lua')).
-          and_return(MrMurano::SyncUpDown::Item.new({:name=>'three.lua', :updated_at=>ITEM_UPDATED_AT}))
+          and_return(MrMurano::SyncUpDown::Item.new({name: 'three.lua', updated_at: ITEM_UPDATED_AT}))
         expect(@t).to receive(:to_remote_item).
           with(anything(), pathname_globs('**/four.lua')).
-          and_return(MrMurano::SyncUpDown::Item.new({:name=>'four.lua', :updated_at=>ITEM_UPDATED_AT}))
+          and_return(MrMurano::SyncUpDown::Item.new({name: 'four.lua', updated_at: ITEM_UPDATED_AT}))
         expect(@t).to receive(:to_remote_item).
           with(anything(), pathname_globs('**/five.lua')).
-          and_return(MrMurano::SyncUpDown::Item.new({:name=>'five.lua', :updated_at=>ITEM_UPDATED_AT}))
+          and_return(MrMurano::SyncUpDown::Item.new({name: 'five.lua', updated_at: ITEM_UPDATED_AT}))
         expect(@t).to receive(:to_remote_item).
           with(anything(), pathname_globs('**/six.lua')).
-          and_return(MrMurano::SyncUpDown::Item.new({:name=>'six.lua', :updated_at=>ITEM_UPDATED_AT}))
+          and_return(MrMurano::SyncUpDown::Item.new({name: 'six.lua', updated_at: ITEM_UPDATED_AT}))
 
-        expect(@t).to receive(:docmp).with(have_attributes({:name=>'one.lua'}),anything()).and_return(true)
-        expect(@t).to receive(:docmp).with(have_attributes({:name=>'two.lua'}),anything()).and_return(true)
-        expect(@t).to receive(:docmp).with(have_attributes({:name=>'three.lua'}),anything()).and_return(false)
-        expect(@t).to receive(:docmp).with(have_attributes({:name=>'four.lua'}),anything()).and_return(false)
+        expect(@t).to receive(:docmp).with(have_attributes({name: 'one.lua'}),anything()).and_return(true)
+        expect(@t).to receive(:docmp).with(have_attributes({name: 'two.lua'}),anything()).and_return(true)
+        expect(@t).to receive(:docmp).with(have_attributes({name: 'three.lua'}),anything()).and_return(false)
+        expect(@t).to receive(:docmp).with(have_attributes({name: 'four.lua'}),anything()).and_return(false)
       end
 
       it "Returns all with no filter" do
         ret = @t.status
         expect(ret).to match({
-          :unchg=>[
+          unchg: [
             have_attributes(
               {
-                :name=>'four.lua',
-                :synckey=>'four.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/four.lua'),
+                name: 'four.lua',
+                synckey: 'four.lua',
+                synctype: TSUD.description,
+                local_path: pathname_globs('**/four.lua'),
               }),
             have_attributes(
               {
-                :name=>'three.lua',
-                :synckey=>'three.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/three.lua'),
-              }),
-          ],
-          :toadd=>[
-            have_attributes(
-              {
-                :name=>'five.lua',
-                :synckey=>'five.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/five.lua'),
-              }),
-            have_attributes(
-              {
-                :name=>'six.lua',
-                :synckey=>'six.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/six.lua'),
+                name: 'three.lua',
+                synckey: 'three.lua',
+                synctype: TSUD.description,
+                local_path: pathname_globs('**/three.lua'),
               }),
           ],
-          :todel=>[
+          toadd: [
             have_attributes(
               {
-                :name=>'eight.lua',
-                :synckey=>'eight.lua',
-                :synctype=>TSUD.description,
+                name: 'five.lua',
+                synckey: 'five.lua',
+                synctype: TSUD.description,
+                local_path: pathname_globs('**/five.lua'),
               }),
             have_attributes(
               {
-                :name=>'seven.lua',
-                :synckey=>'seven.lua',
-                :synctype=>TSUD.description,
-              }),
-          ],
-          :tomod=>[
-            have_attributes(
-              {
-                :name=>'one.lua',
-                :synckey=>'one.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/one.lua'),
-              }),
-            have_attributes(
-              {
-                :name=>'two.lua',
-                :synckey=>'two.lua',
-                :synctype=>TSUD.description,
-                :local_path=>pathname_globs('**/two.lua'),
+                name: 'six.lua',
+                synckey: 'six.lua',
+                synctype: TSUD.description,
+                local_path: pathname_globs('**/six.lua'),
               }),
           ],
-          :skipd=>[],
+          todel: [
+            have_attributes(
+              {
+                name: 'eight.lua',
+                synckey: 'eight.lua',
+                synctype: TSUD.description,
+              }),
+            have_attributes(
+              {
+                name: 'seven.lua',
+                synckey: 'seven.lua',
+                synctype: TSUD.description,
+              }),
+          ],
+          tomod: [
+            have_attributes(
+              {
+                name: 'one.lua',
+                synckey: 'one.lua',
+                synctype: TSUD.description,
+                local_path: pathname_globs('**/one.lua'),
+              }),
+            have_attributes(
+              {
+                name: 'two.lua',
+                synckey: 'two.lua',
+                synctype: TSUD.description,
+                local_path: pathname_globs('**/two.lua'),
+              }),
+          ],
+          skipd: [],
+          clash: [],
         })
       end
 
       it "Finds local path globs" do
         ret = @t.status({}, ['**/ga/*.lua'])
         expect(ret).to match({
-          :unchg=>[ ],
-          :toadd=>[
+          unchg: [ ],
+          toadd: [
             have_attributes(
-              :name=>'six.lua',
-              :synckey=>'six.lua',
-              :synctype=>TSUD.description,
-              :local_path=>an_instance_of(Pathname)
+              name: 'six.lua',
+              synckey: 'six.lua',
+              synctype: TSUD.description,
+              local_path: an_instance_of(Pathname)
             ),
           ],
-          :todel=>[ ],
-          :tomod=>[
+          todel: [ ],
+          tomod: [
             have_attributes(
-              :name=>'two.lua',
-              :synckey=>'two.lua',
-              :synctype=>TSUD.description,
-              :local_path=>an_instance_of(Pathname)
+              name: 'two.lua',
+              synckey: 'two.lua',
+              synctype: TSUD.description,
+              local_path: an_instance_of(Pathname)
             ),
           ],
-          :skipd=>[],
+          skipd: [],
+          clash: [],
         })
       end
 
       it "Finds nothing with specific matcher" do
         ret = @t.status({}, ['#foo'])
         expect(ret).to match({
-          :unchg=>[],
-          :toadd=>[],
-          :todel=>[],
-          :tomod=>[],
-          :skipd=>[],
+          unchg: [],
+          toadd: [],
+          todel: [],
+          tomod: [],
+          skipd: [],
+          clash: [],
         })
       end
 
       it "gets all the details" do
-        ret = @t.status({:unselected=>true})
+        ret = @t.status({unselected: true})
         expect(ret).to match({
-          :unchg=>[
+          unchg: [
             have_attributes(
-              :name=>'four.lua',
-              :synckey=>'four.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/four.lua')
+              name: 'four.lua',
+              synckey: 'four.lua',
+              synctype: TSUD.description,
+              selected: true,
+              local_path: pathname_globs('**/four.lua')
               ),
             have_attributes(
-              :name=>'three.lua',
-              :synckey=>'three.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/three.lua')
+              name: 'three.lua',
+              synckey: 'three.lua',
+              synctype: TSUD.description,
+              selected: true,
+              local_path: pathname_globs('**/three.lua')
             ),
           ],
-          :toadd=>[
+          toadd: [
             have_attributes(
-              :name=>'five.lua',
-              :synckey=>'five.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/five.lua')
+              name: 'five.lua',
+              synckey: 'five.lua',
+              synctype: TSUD.description,
+              selected: true,
+              local_path: pathname_globs('**/five.lua')
             ),
             have_attributes(
-              :name=>'six.lua',
-              :synckey=>'six.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/six.lua')
-            ),
-          ],
-          :todel=>[
-            have_attributes(
-              :name=>'eight.lua',
-              :selected=>true,
-              :synckey=>'eight.lua',
-              :synctype=>TSUD.description,
-            ),
-            have_attributes(
-              :name=>'seven.lua',
-              :selected=>true,
-              :synckey=>'seven.lua',
-              :synctype=>TSUD.description,
+              name: 'six.lua',
+              synckey: 'six.lua',
+              synctype: TSUD.description,
+              selected: true,
+              local_path: pathname_globs('**/six.lua')
             ),
           ],
-          :tomod=>[
+          todel: [
             have_attributes(
-              :name=>'one.lua',
-              :synckey=>'one.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/one.lua')
+              name: 'eight.lua',
+              selected: true,
+              synckey: 'eight.lua',
+              synctype: TSUD.description,
             ),
             have_attributes(
-              :name=>'two.lua',
-              :synckey=>'two.lua',
-              :synctype=>TSUD.description,
-              :selected=>true,
-              :local_path=>pathname_globs('**/two.lua')
+              name: 'seven.lua',
+              selected: true,
+              synckey: 'seven.lua',
+              synctype: TSUD.description,
             ),
           ],
-          :skipd=>[],
+          tomod: [
+            have_attributes(
+              name: 'one.lua',
+              synckey: 'one.lua',
+              synctype: TSUD.description,
+              selected: true,
+              local_path: pathname_globs('**/one.lua')
+            ),
+            have_attributes(
+              name: 'two.lua',
+              synckey: 'two.lua',
+              synctype: TSUD.description,
+              selected: true,
+              local_path: pathname_globs('**/two.lua')
+            ),
+          ],
+          skipd: [],
+          clash: [],
         })
       end
     end
@@ -491,18 +505,18 @@ RSpec.describe MrMurano::SyncUpDown do
     end
     it "finds local items" do
       expect(@t).to receive(:to_remote_item).and_return(
-        {:name=>'one.lua'},
-        {:name=>'two.lua'},
+        {name: 'one.lua'},
+        {name: 'two.lua'},
       )
       ret = @t.localitems(Pathname.new(@project_dir + '/tsud').realpath)
       expect(ret).to match([
         {
-          :name=>'one.lua',
-          :local_path=>an_instance_of(Pathname)
+          name: 'one.lua',
+          local_path: an_instance_of(Pathname)
         },
         {
-          :name=>'two.lua',
-          :local_path=>an_instance_of(Pathname)
+          name: 'two.lua',
+          local_path: an_instance_of(Pathname)
         },
       ])
     end
@@ -510,31 +524,31 @@ RSpec.describe MrMurano::SyncUpDown do
     it "takes an array from to_remote_item" do
       expect(@t).to receive(:to_remote_item).and_return(
         [
-          {:name=>'one:1'},
-          {:name=>'one:2'},
+          {name: 'one:1'},
+          {name: 'one:2'},
         ],
         [
-          {:name=>'two:1'},
-          {:name=>'two:2'},
+          {name: 'two:1'},
+          {name: 'two:2'},
         ],
       )
       ret = @t.localitems(Pathname.new(@project_dir + '/tsud').realpath)
       expect(ret).to match([
         {
-          :name=>'one:1',
-          :local_path=>an_instance_of(Pathname),
+          name: 'one:1',
+          local_path: an_instance_of(Pathname),
         },
         {
-          :name=>'one:2',
-          :local_path=>an_instance_of(Pathname),
+          name: 'one:2',
+          local_path: an_instance_of(Pathname),
         },
         {
-          :name=>'two:1',
-          :local_path=>an_instance_of(Pathname),
+          name: 'two:1',
+          local_path: an_instance_of(Pathname),
         },
         {
-          :name=>'two:2',
-          :local_path=>an_instance_of(Pathname),
+          name: 'two:2',
+          local_path: an_instance_of(Pathname),
         },
       ])
     end
@@ -547,7 +561,7 @@ RSpec.describe MrMurano::SyncUpDown do
       lp = Pathname.new(@project_dir + '/tsud/one.lua').realpath
       t = TSUD.new
       expect(t).to receive(:fetch).once.with(1).and_yield("foo")
-      t.download(lp, {:id=>1, :updated_at=>ITEM_UPDATED_AT})
+      t.download(lp, {id: 1, updated_at: ITEM_UPDATED_AT})
     end
   end
 
@@ -618,12 +632,12 @@ RSpec.describe MrMurano::SyncUpDown do
 
     it "removes" do
       expect(@t).to receive(:list).once.and_return([
-        {:name=>1},
-        {:name=>2},
-        {:name=>3},
+        {name: 1},
+        {name: 2},
+        {name: 3},
       ])
       expect(@t).to receive(:remove).exactly(3).times
-      @t.syncup({:delete=>true})
+      @t.syncup({delete: true})
     end
 
     it "creates" do
@@ -631,25 +645,25 @@ RSpec.describe MrMurano::SyncUpDown do
       FileUtils.touch(@project_dir + '/tsud/two.lua')
 
       expect(@t).to receive(:upload).twice.with(kind_of(Pathname), kind_of(MrMurano::SyncUpDown::Item), false)
-      @t.syncup({:create=>true})
+      @t.syncup({create: true})
     end
 
     it "updates" do
       FileUtils.touch(@project_dir + '/tsud/one.lua')
       FileUtils.touch(@project_dir + '/tsud/two.lua')
       expect(@t).to receive(:list).once.and_return([
-        MrMurano::SyncUpDown::Item.new({:name=>'one.lua', :updated_at=>ITEM_UPDATED_AT}),
-        MrMurano::SyncUpDown::Item.new({:name=>'two.lua', :updated_at=>ITEM_UPDATED_AT})
+        MrMurano::SyncUpDown::Item.new({name: 'one.lua', updated_at: ITEM_UPDATED_AT}),
+        MrMurano::SyncUpDown::Item.new({name: 'two.lua', updated_at: ITEM_UPDATED_AT})
       ])
 
       expect(@t).to receive(:upload).twice.with(
         kind_of(Pathname), kind_of(MrMurano::SyncUpDown::Item), true
       )
       expect(@t).to receive(:to_remote_item).and_return(
-        {:name=>'one.lua'},
-        {:name=>'two.lua'},
+        {name: 'one.lua'},
+        {name: 'two.lua'},
       )
-      @t.syncup({:update=>true})
+      @t.syncup({update: true})
     end
   end
 
@@ -670,8 +684,8 @@ RSpec.describe MrMurano::SyncUpDown do
 
     it "creates" do
       expect(@t).to receive(:list).once.and_return([
-        MrMurano::SyncUpDown::Item.new({:name=>'one.lua', :updated_at=>ITEM_UPDATED_AT}),
-        MrMurano::SyncUpDown::Item.new({:name=>'two.lua', :updated_at=>ITEM_UPDATED_AT})
+        MrMurano::SyncUpDown::Item.new({name: 'one.lua', updated_at: ITEM_UPDATED_AT}),
+        MrMurano::SyncUpDown::Item.new({name: 'two.lua', updated_at: ITEM_UPDATED_AT})
       ])
 
       expect(@t).to receive(:fetch).twice.and_yield("--foo\n")
@@ -684,14 +698,14 @@ RSpec.describe MrMurano::SyncUpDown do
       FileUtils.touch(@project_dir + '/tsud/one.lua')
       FileUtils.touch(@project_dir + '/tsud/two.lua')
       expect(@t).to receive(:list).once.and_return([
-        MrMurano::SyncUpDown::Item.new({:name=>'one.lua', :updated_at=>ITEM_UPDATED_AT}),
-        MrMurano::SyncUpDown::Item.new({:name=>'two.lua', :updated_at=>ITEM_UPDATED_AT})
+        MrMurano::SyncUpDown::Item.new({name: 'one.lua', updated_at: ITEM_UPDATED_AT}),
+        MrMurano::SyncUpDown::Item.new({name: 'two.lua', updated_at: ITEM_UPDATED_AT})
       ])
 
       expect(@t).to receive(:fetch).twice.and_yield("--foo\n")
       expect(@t).to receive(:to_remote_item).and_return(
-        MrMurano::SyncUpDown::Item.new({:name=>'one.lua', :updated_at=>ITEM_UPDATED_AT}),
-        MrMurano::SyncUpDown::Item.new({:name=>'two.lua', :updated_at=>ITEM_UPDATED_AT})
+        MrMurano::SyncUpDown::Item.new({name: 'one.lua', updated_at: ITEM_UPDATED_AT}),
+        MrMurano::SyncUpDown::Item.new({name: 'two.lua', updated_at: ITEM_UPDATED_AT})
       )
       @t.syncdown(update: true)
       expect(FileTest.exist?(@project_dir + '/tsud/one.lua')).to be true
@@ -711,15 +725,15 @@ RSpec.describe MrMurano::SyncUpDown do
 #      FileUtils.touch(@project_dir + '/bundles/mybun/tsud/two.lua')
 #
 #      expect(@t).to receive(:to_remote_item).and_return(
-#        {:name=>'two.lua'},{:name=>'one.lua'}
+#        {name: 'two.lua'},{name: 'one.lua'}
 #      )
 #      ret = @t.locallist
 #      expect(ret).to match([
-#        {:name=>'two.lua',
-#         :bundled=>true,
-#         :local_path=>an_instance_of(Pathname)},
-#        {:name=>'one.lua',
-#         :local_path=>an_instance_of(Pathname)},
+#        {name: 'two.lua',
+#         bundled: true,
+#         local_path: an_instance_of(Pathname)},
+#        {name: 'one.lua',
+#         local_path: an_instance_of(Pathname)},
 #      ])
 #    end
 #
@@ -729,7 +743,7 @@ RSpec.describe MrMurano::SyncUpDown do
 #
 #      expect(@t).to receive(:warning).once.with(/Not downloading into bundled item.*/)
 #
-#      @t.download(lp, {:bundled=>true, :name=>'one.lua'})
+#      @t.download(lp, {bundled: true, name: 'one.lua'})
 #    end
 #  end
 end


### PR DESCRIPTION
## Murano CLI v3.0.1

### Highlights

- Alias filename parts and magic script header using config variables, e.g., use `{product.id}` instead of actual Product ID.

- Disable progress bar if command is being piped.

- New `device enable --expire` option, and new `lock`, `unlock`, and `revoke` device commands.

- Fix `--help` issues.

- New global option, `--ascii`, ensures no Unicode is used in output.

- A handful of bug fixes.

### Product ID Event Handler Aliasing

Support config variable aliases in filenames and event handler scripts.

- For instance, instead of specifying the Product ID in the filename, such as

    `"services/abcd1234_event.lua"`

  you can name it with a config variable,

     `"services/{product.id}_event.lua"`

- And instead of hard coding the ID in the magic header, e.g.,

     `"--#EVENT a1b2c3d4e5f6 event"`

  you can use the same config variable substitution, e.g.,

     `"--#EVENT {product.id} event"`

### Disable Progress if Command Being Piped

If the `murano` command is being piped (or run in a subshell), disable the progress display, which adds hidden characters to any captured output.

- E.g., for commands like `URL=$(murano domain application --brief)` and `murano usage | grep email | awk '{print $4}'`

### New `device` Commands and Options

- New `--expire` option for the `device enable` command specifies the number of hours until the authentication window closes (and the device in Murano must be re-enabled before the physical device can authenticate).

- New device commands: `device lock`, `device unlock`, and `device revoke`.

### Improve `--help`

Multiple fixes to the help system:

- Fix `--help` to work when other --options are present.
  
- Fix `--help` on base commands to show list of subcommands (was showing just the description).

- Fix `--help` to work on command aliases (was erroneously telling you to run `--help`).

- New command line option `--no-page` and corresponding config variable `tool.no-page` disable paging the help.

### New global option, `--ascii`

Disable Unicode output with `--ascii` (the progress bar defaults to using Unicode, as do some messages).

### Bugfixes

Various bugfixes to:

- `murano domain product` incorrectly showing application, too.

- `murano business find` failing on fuzzy search.

- `murano device enable` command was using old API.