### PR TITLE
Enhance error output on syncdown; let use --ignore-errors

### DIFF
--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -195,7 +195,7 @@ module MrMurano
         @here = locallist
       end
 
-      def download(_local, item)
+      def download(_local, item, _options=nil)
         # Not calling, e.g., `return unless download_item_allowed(item[@itemkey])`
         #   See instead: syncup_after and syncdown_after/resources_write
         @here = locallist if @here.nil?

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -67,6 +67,7 @@ module MrMurano
       else
         # I.e., thereitem.phantom, an "undeletable" file that does not
         # exist locally but should not be deleted from server.
+        # MAYBE/2017-09-07: Honor options.ignore_errors here?
         raise 'no file' unless thereitem.script
         script = thereitem.script
       end

--- a/lib/MrMurano/Solution-Users.rb
+++ b/lib/MrMurano/Solution-Users.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -56,7 +56,7 @@ module MrMurano
       post('/', remote)
     end
 
-    def download(local, item)
+    def download(local, item, _options=nil)
       # needs to append/merge with file
       # for now, we'll read, modify, write
       here = []

--- a/lib/MrMurano/Webservice-Endpoint.rb
+++ b/lib/MrMurano/Webservice-Endpoint.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -108,6 +108,7 @@ module MrMurano
       # @param modify [Boolean] True if item exists already and this is changing it
       def upload(local, remote, _modify)
         local = Pathname.new(local) unless local.is_a? Pathname
+        # MAYBE/2017-09-07: Honor options.ignore_errors here?
         raise 'no file' unless local.exist?
         # we assume these are small enough to slurp.
         if remote.script.nil?

--- a/lib/MrMurano/commands/sync.rb
+++ b/lib/MrMurano/commands/sync.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.09.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -13,6 +13,7 @@ def sync_add_options(c, locale)
   c.option '--[no-]delete', %(Don't delete things from #{locale})
   c.option '--[no-]create', %(Don't create things on #{locale})
   c.option '--[no-]update', %(Don't update things on #{locale})
+  c.option '--ignore-errors', %(Don't die on sync errors)
 end
 
 def syncdown_files(options, args=nil)

--- a/lib/MrMurano/hash.rb
+++ b/lib/MrMurano/hash.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.30 /coding: utf-8
+# Last Modified: 2017.09.07 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -73,9 +73,10 @@ def elevate_hash(hsh)
   end
   # build a hash where the default is 'false' instead of 'nil'
   Hash.new(false).merge(Hash.transform_keys_to_symbols(hsh))
-  # 2017-08-16: Weird: [lb] seeing the Hash behave differently
-  #   after feeding through this function. Unknown keys would
-  #   return nil before, but after, return false.
+  # 2017-09-07: Note that after elevate_hash, the Hash returns
+  #   false on unknown keys. This is because of the parameter to
+  #   new: Hash.new(false). Unknown keys would return nil before,
+  #   but after, they return false. E.g.,
   #
   #   (byeebug) options
   #   {:delete=>false, :create=>true, :update=>false}
@@ -89,8 +90,6 @@ def elevate_hash(hsh)
   #   false
   #   (byeebug) options
   #   {:delete=>false, :create=>true, :update=>false, :fff=>nil}
-  #
-  #   Work around is to test with hash.key?
 end
 
 ##


### PR DESCRIPTION
User reported error in download -- remote item missing `:id` field, and Murano CLI raises.

https://i.exosite.com/jira/browse/MRMUR-156

I can not reproduce this, so I added additional logging, including the complete item hash and the local pathname.

Also add new `--ignore-errors` option to let user tell Murano CLI not to raise, but to keep on syncin'.