### PR TITLE
Feature/mrmur 159 api id vs sid

### DIFF
--- a/.agignore
+++ b/.agignore
@@ -10,6 +10,7 @@ Gemfile.lock
 
 # 2017-05-12: Testing!
 *.out
+.rake_build.out
 
 rspec-*.html
 *.rspec.html

--- a/README.markdown
+++ b/README.markdown
@@ -375,9 +375,9 @@ EOF
 
 cat >> .murano.stg <<EOF
 [application]
-id=JJJJJJJJ
+id=LLLLLLLL
 [product]
-id=KKKKKKKK
+id=MMMMMMMM
 EOF
 
 cat >> .murano.prod <<EOF

--- a/docs/completions/murano_completion-bash
+++ b/docs/completions/murano_completion-bash
@@ -10,6 +10,10 @@ __app_switches=(
     --configfile
     --curl
     --dry
+    --csv
+    --json
+    --yaml
+    --pp
     --exclude-scopes
     --no-page
     --no-plugins

--- a/lib/MrMurano/Business.rb
+++ b/lib/MrMurano/Business.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.29 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.

--- a/lib/MrMurano/Business.rb
+++ b/lib/MrMurano/Business.rb
@@ -166,7 +166,7 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
     #ALLOWED_TYPES = [:domain, :onepApi, :dataApi, :application, :product,].freeze
     ALLOWED_TYPES = %i[application product].freeze
 
-    def solutions(type: :all, sid: nil, name: nil, fuzzy: nil, invalidate: false)
+    def solutions(type: :all, api_id: nil, name: nil, fuzzy: nil, invalidate: false)
       debug "Getting all solutions of type #{type}"
       must_business_id!
 
@@ -201,16 +201,17 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
 
       solz = @user_bizes[type].dup
 
-      match_sid = ensure_array(sid)
+      match_api_id = ensure_array(api_id)
       match_name = ensure_array(name)
       match_fuzzy = ensure_array(fuzzy)
-      if match_sid.any? || match_name.any? || match_fuzzy.any?
+      if match_api_id.any? || match_name.any? || match_fuzzy.any?
         solz.select! do |sol|
           (
-            match_sid.include?(sol[:apiId]) ||
+            match_api_id.include?(sol[:apiId]) ||
             match_name.include?(sol[:name]) ||
             match_fuzzy.any? do |term|
-              sol[:name] =~ /#{Regexp.escape(term)}/i || sol[:apiId] =~ /#{Regexp.escape(term)}/i
+              sol[:name] =~ /#{Regexp.escape(term)}/i || \
+                sol[:apiId] =~ /#{Regexp.escape(term)}/i
             end
           )
         end
@@ -224,7 +225,9 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
           MrMurano::Product.new(meta)
         else
           warning("Unexpected solution type: #{meta[:type]}")
-          warning('* Please enable Murano for this business') if meta[:type].to_sym == :dataApi
+          if meta[:type].to_sym == :dataApi
+            warning('* Please enable Murano for this business')
+          end
           MrMurano::Solution.new(meta)
         end
       end
@@ -241,14 +244,14 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
     def solution_from_type!(type)
       type = type.to_s.to_sym
       raise "Unknown type(#{type})" unless type.to_s.empty? || ALLOWED_TYPES.include?(type)
-      sid = MrMurano::Solution::INVALID_SID
+      api_id = MrMurano::Solution::INVALID_API_ID
       if type == :application
-        sol = MrMurano::Application.new(sid)
+        sol = MrMurano::Application.new(api_id)
       elsif type == :product
-        sol = MrMurano::Product.new(sid)
+        sol = MrMurano::Product.new(api_id)
       else
         #raise "Unexpected path: Unrecognized type #{fancy_ticks(type)}"
-        sol = MrMurano::Solution.new(sid)
+        sol = MrMurano::Solution.new(api_id)
       end
       sol.biz = self
       sol
@@ -312,7 +315,7 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
         error("Unexpected: Solution ID not returned: #{resp}")
         exit 1
       end
-      sol.sid = resp[:id]
+      sol.api_id = resp[:id]
       sol.affirm_valid
       # 2017-06-29: The code used to hunt for the solution ID, because
       #   POST business/<bizid>/solution/ used to not return anything,
@@ -333,11 +336,11 @@ or set it interactively using \`#{MrMurano::EXE_NAME} init\`
       #    exit 3
       #  end
       #  sol.meta = ret.first
-      #  if sol.sid.to_s.empty? then
+      #  if sol.api_id.to_s.empty? then
       #    error("New solution created for #{fancy_ticks(sol.name)} missing ID?: #{ret}")
       #    exit 3
       #  end
-      #  sol.sid = sid
+      #  sol.api_id = api_id
       #end
       sol
     end

--- a/lib/MrMurano/Content.rb
+++ b/lib/MrMurano/Content.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -29,9 +29,9 @@ module MrMurano
 
       def initialize
         @solntype = 'product.id'
-        @uriparts_sidex = 1
-        init_sid!
-        @uriparts = [:service, @sid, :content, :item]
+        @uriparts_apidex = 1
+        init_api_id!
+        @uriparts = [:service, @api_id, :content, :item]
         @itemkey = :id
         #@locationbase = $cfg['location.base']
         @location = nil

--- a/lib/MrMurano/Gateway.rb
+++ b/lib/MrMurano/Gateway.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.07 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -29,10 +29,10 @@ module MrMurano
 
       def initialize
         @solntype = 'product.id'
-        @uriparts_sidex = 1
-        init_sid!
-        @uriparts = [:service, @sid, :device2]
-        @uriparts_sidex = 1
+        @uriparts_apidex = 1
+        init_api_id!
+        @uriparts = [:service, @api_id, :device2]
+        @uriparts_apidex = 1
         @itemkey = :id
       end
 
@@ -463,7 +463,7 @@ module MrMurano
         raise "Gateway info not found for #{identifier}" if info.nil?
         fqdn = info[:fqdn]
         debug "Found FQDN: #{fqdn}"
-        fqdn = "#{@sid}.m2.exosite.io" if fqdn.nil?
+        fqdn = "#{@api_id}.m2.exosite.io" if fqdn.nil?
 
         uri = URI("https://#{fqdn}/provision/activate")
         http = Net::HTTP.new(uri.host, uri.port)
@@ -471,8 +471,8 @@ module MrMurano
         http.start
         request = Net::HTTP::Post.new(uri)
         request.form_data = {
-          vendor: @sid,
-          model: @sid,
+          vendor: @api_id,
+          model: @api_id,
           sn: identifier,
         }
         request['User-Agent'] = "MrMurano/#{MrMurano::VERSION}"

--- a/lib/MrMurano/Keystore.rb
+++ b/lib/MrMurano/Keystore.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.28 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -9,7 +9,7 @@ require 'MrMurano/Solution-ServiceConfig'
 
 module MrMurano
   class Keystore < ServiceConfig
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       # FIXME/2017-07-03: Do products have a keystore service? What about other soln types?
       @solntype = 'application.id'
       super

--- a/lib/MrMurano/Solution-ServiceConfig.rb
+++ b/lib/MrMurano/Solution-ServiceConfig.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -10,7 +10,7 @@ require 'MrMurano/Solution'
 module MrMurano
   # …/serviceconfig
   class ServiceConfig < SolutionBase
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       super
       @uriparts << :serviceconfig
       @scid = nil
@@ -58,7 +58,7 @@ module MrMurano
       post(
         '/',
         {
-          solution_id: @sid,
+          solution_id: @api_id,
           service: pid,
           # 2017-06-26: "name" seems to work, but "script_key" is what web UI uses.
           #   See yeti-ui/bridge/src/js/api/services.js::linkApplicationService
@@ -112,20 +112,20 @@ module MrMurano
   # A much better UI/UX happens with human intervention.
   # :nocov:
   class Services < SolutionBase
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       super
       @uriparts << :service
     end
 
-    def sid_for_name(name)
+    def api_id_for_name(name)
       name = name.to_s unless name.is_a? String
       scr = list.select { |i| i[:alias] == name }.first
       scr[:id]
     end
 
-    def sid
-      return @sid unless @sid.nil?
-      @sid = sid_for_name(@service_name)
+    def api_id
+      return @api_id unless @api_id.nil?
+      @api_id = api_id_for_name(@service_name)
     end
 
     def list
@@ -137,13 +137,13 @@ module MrMurano
       #   sort_by_name(ret[:items])
     end
 
-    def schema(id=sid)
+    def schema(id=api_id)
       # TODO: cache schema in user dir?
       get("/#{id}/schema")
     end
 
     ## Get list of call operations from a schema
-    def callable(id=sid, all=false)
+    def callable(id=api_id, all=false)
       scm = schema(id)
       calls = []
       scm[:paths].each do |path, methods|
@@ -174,14 +174,14 @@ module MrMurano
   # :nocov:
 
   class ServiceConfigApplication < ServiceConfig
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       @solntype = 'application.id'
       super
     end
   end
 
   class ServiceConfigProduct < ServiceConfig
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       @solntype = 'product.id'
       super
     end

--- a/lib/MrMurano/Solution-Services.rb
+++ b/lib/MrMurano/Solution-Services.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.07 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -21,7 +21,7 @@ module MrMurano
   ##
   # Things that servers do that is common.
   class ServiceBase < SolutionBase
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       super
     end
 
@@ -78,7 +78,7 @@ module MrMurano
       name = mkname(thereitem)
       pst = thereitem.to_h.merge(
         #solution_id: $cfg[@solntype],
-        solution_id: @sid,
+        solution_id: @api_id,
         script: script,
         alias: mkalias(thereitem),
         name: name,
@@ -175,7 +175,7 @@ module MrMurano
       [
         'cache',
         self.class.to_s.gsub(/\W+/, '_'),
-        @sid,
+        @api_id,
         'yaml',
       ].join('.')
     end
@@ -259,7 +259,7 @@ module MrMurano
       attr_accessor :solution_id
     end
 
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       @solntype = 'application.id'
       super
       @uriparts << :module
@@ -284,7 +284,7 @@ module MrMurano
     def mkalias(remote)
       raise "Missing parts! #{remote.to_h.to_json}" if remote.name.nil?
       #[$cfg[@solntype], remote[:name]].join('_')
-      [@sid, remote[:name]].join('_')
+      [@api_id, remote[:name]].join('_')
     end
 
     def mkname(remote)
@@ -350,7 +350,7 @@ module MrMurano
       attr_accessor :updated_at
       # @return [String] Timestamp when this was created.
       attr_accessor :created_at
-      # @return [String] The soln's product.id or application.id (Murano's apiId).
+      # @return [String] The soln's product.id or application.id (Murano's api_id).
       attr_accessor :solution_id
       # @return [String] Which service triggers this script.
       attr_accessor :service
@@ -367,7 +367,7 @@ module MrMurano
       attr_accessor :phantom
     end
 
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       super
       @uriparts << :eventhandler
       @itemkey = :alias
@@ -379,7 +379,7 @@ module MrMurano
     def mkalias(remote)
       raise "Missing parts! #{remote.to_h.to_json}" if remote.service.nil? || remote.event.nil?
       #[$cfg[@solntype], remote[:service], remote[:event]].join('_')
-      [@sid, remote[:service], remote[:event]].join('_')
+      [@api_id, remote[:service], remote[:event]].join('_')
     end
 
     def mkname(remote)
@@ -483,12 +483,12 @@ module MrMurano
       end
     end
 
-    def default_event_script(service_or_sid, &block)
+    def default_event_script(service_or_api_id, &block)
       post(
         '/',
         {
-          solution_id: @sid,
-          service: service_or_sid,
+          solution_id: @api_id,
+          service: service_or_api_id,
           event: 'event',
           script: 'print(event)',
         },
@@ -713,7 +713,7 @@ module MrMurano
   PRODUCT_SERVICES = %w[device2 interface].freeze
 
   class EventHandlerSolnPrd < EventHandler
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       @solntype = 'product.id'
       # FIXME/2017-06-20: Should we use separate directories for prod vs app?
       #   See also :services in PrfFile and elsewhere;
@@ -749,7 +749,7 @@ module MrMurano
   end
 
   class EventHandlerSolnApp < EventHandler
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       @solntype = 'application.id'
       # FIXME/2017-06-20: Should we use separate directories for prod vs app?
       @project_section = :services

--- a/lib/MrMurano/SolutionId.rb
+++ b/lib/MrMurano/SolutionId.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -9,68 +9,68 @@ require 'MrMurano/verbosing'
 
 module MrMurano
   module SolutionId
-    INVALID_SID = '-1'
+    INVALID_API_ID = '-1'
     UNEXPECTED_TYPE_OR_ERROR_MSG = (
       'Unexpected result type or error: assuming empty instead'
     )
 
+    attr_reader :api_id
+    attr_reader :valid_api_id
     attr_reader :sid
-    attr_reader :valid_sid
 
-    def init_sid!(sid=nil)
-      @valid_sid = false
+    def init_api_id!(api_id=nil)
+      @valid_api_id = false
       unless defined?(@solntype) && @solntype
         # Note that 'solution.id' isn't an actual config setting;
         # see instead 'application.id' and 'product.id'. We just
         # use 'solution.id' to indicate that the caller specified
         # a solution ID explicitly (i.e., it's not from the $cfg).
-        raise 'Missing sid or class @solntype!?' if sid.to_s.empty?
+        raise 'Missing api_id or class @solntype!?' if api_id.to_s.empty?
         @solntype = 'solution.id'
       end
-      if sid
-        self.sid = sid
+      if api_id
+        self.api_id = api_id
       else
         # Get the application.id or product.id.
-        self.sid = $cfg[@solntype]
+        self.api_id = $cfg[@solntype]
       end
       # Maybe raise 'No application!' or 'No product!'.
-      return unless @sid.to_s.empty?
+      return unless @api_id.to_s.empty?
       raise MrMurano::ConfigError.new("No #{/(.*).id/.match(@solntype)[1]} ID!")
     end
 
-    def sid?
-      # The @sid should never be nil or empty, but let's at least check.
-      @sid != INVALID_SID && !@sid.to_s.empty?
+    def api_id?
+      # The @api_id should never be nil or empty, but let's at least check.
+      @api_id != INVALID_API_ID && !@api_id.to_s.empty?
     end
 
-    def sid=(sid)
-      sid = INVALID_SID if sid.nil? || !sid.is_a?(String) || sid.empty?
-      if sid.to_s.empty? || sid == INVALID_SID || (defined?(@sid) && sid != @sid)
-        @valid_sid = false
+    def api_id=(api_id)
+      api_id = INVALID_API_ID if api_id.nil? || !api_id.is_a?(String) || api_id.empty?
+      if api_id.to_s.empty? || api_id == INVALID_API_ID || (defined?(@api_id) && api_id != @api_id)
+        @valid_api_id = false
       end
-      @sid = sid
-      # MAGIC_NUMBER: The 2nd element is the solution ID, e.g., solution/<sid>/...
-      raise "Unexpected @uriparts_sidex #{@uriparts_sidex}" unless @uriparts_sidex == 1
+      @api_id = api_id
+      # MAGIC_NUMBER: The 2nd element is the solution ID, e.g., solution/<api_id>/...
+      raise "Unexpected @uriparts_apidex #{@uriparts_apidex}" unless @uriparts_apidex == 1
       # We're called on initialize before @uriparts is built, so don't always do this.
-      @uriparts[@uriparts_sidex] = @sid if defined?(@uriparts)
+      @uriparts[@uriparts_apidex] = @api_id if defined?(@uriparts)
     end
 
     def affirm_valid
-      @valid_sid = true
+      @valid_api_id = true
     end
 
-    def valid_sid?
-      @valid_sid
+    def valid_api_id?
+      @valid_api_id
     end
 
-    # rubocop:disable Style/MethodName
-    def apiId
-      @sid
+    def api_id
+      @api_id
     end
 
     def endpoint(_path='')
       # This is hopefully just a DEV error, and not something user will ever see!
-      return unless @uriparts[@uriparts_sidex] == INVALID_SID
+      return unless @uriparts[@uriparts_apidex] == INVALID_API_ID
       error("Solution ID missing! Invalid #{MrMurano::Verbose.fancy_ticks(@solntype)}")
       exit 2
     end

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.07 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -409,14 +409,14 @@ module MrMurano
     end
 
     def syncup_before
-      syncable_validate_sid
+      syncable_validate_api_id
     end
 
     def syncup_after
     end
 
     def syncdown_before
-      syncable_validate_sid
+      syncable_validate_api_id
     end
 
     def syncdown_after(_local)
@@ -917,9 +917,10 @@ module MrMurano
       # Get the solution name from the config.
       # Convert, e.g., application.id => application.name
       soln_name = $cfg[@solntype.gsub(/(.*)\.id/, '\1.name')]
-      # Skip this syncable if the sid is not set, or if user wants to skip by solution.
+      # Skip this syncable if the api_id is not set, or if user wants to skip
+      # by solution.
       skip_sol = false
-      if !sid? ||
+      if !api_id? ||
          (options[:type] == :application && @solntype != 'application.id') ||
          (options[:type] == :product && @solntype != 'product.id')
         skip_sol = true
@@ -931,13 +932,13 @@ module MrMurano
           # nil on unknown keys, so preface with a key? guard.
           if options.key?(:application) && !options[:application].to_s.empty?
             if soln_name =~ /#{Regexp.escape(options[:application])}/i ||
-               sid =~ /#{Regexp.escape(options[:application])}/i
+               api_id =~ /#{Regexp.escape(options[:application])}/i
               passed = true
             end
             tested = true
           end
           if options.key?(:application_id) && !options[:application_id].to_s.empty?
-            passed = true if options[:application_id] == sid
+            passed = true if options[:application_id] == api_id
             tested = true
           end
           if options.key?(:application_name) && !options[:application_name].to_s.empty?
@@ -947,13 +948,13 @@ module MrMurano
         elsif @solntype == 'product.id'
           if options.key?(:product) && !options[:product].to_s.empty?
             if soln_name =~ /#{Regexp.escape(options[:product])}/i ||
-               sid =~ /#{Regexp.escape(options[:product])}/i
+               api_id =~ /#{Regexp.escape(options[:product])}/i
               passed = true
             end
             tested = true
           end
           if options.key?(:product_id) && !options[:product_id].to_s.empty?
-            passed = true if options[:product_id] == sid
+            passed = true if options[:product_id] == api_id
             tested = true
           end
           if options.key?(:product_name) && !options[:product_name].to_s.empty?
@@ -969,13 +970,13 @@ module MrMurano
       ret
     end
 
-    def syncable_validate_sid
+    def syncable_validate_api_id
       # 2017-07-02: Now that there are multiple solution types, and because
       # SyncRoot.add is called on different classes that go with either or
       # both products and applications, if a user only created one solution,
-      # then some syncables will have their sid set to -1, because there's
+      # then some syncables will have their api_id set to -1, because there's
       # not a corresponding solution in Murano.
-      raise 'Syncable missing sid or not valid_sid??!' unless sid?
+      raise 'Syncable missing api_id or not valid_api_id??!' unless api_id?
     end
 
     def items_lists(options, selected)

--- a/lib/MrMurano/Webservice.rb
+++ b/lib/MrMurano/Webservice.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -22,11 +22,11 @@ module MrMurano
 
       def initialize
         @solntype = 'application.id'
-        @uriparts_sidex = 1
-        init_sid!
+        @uriparts_apidex = 1
+        init_api_id!
         # FIXME/2017-06-05/MRMUR-XXXX: Update to new endpoint.
-        #@uriparts = [:service, @sid, :webservice]
-        @uriparts = [:solution, @sid]
+        #@uriparts = [:service, @api_id, :webservice]
+        @uriparts = [:solution, @api_id]
         @itemkey = :id
         #@locationbase = $cfg['location.base']
         @location = nil

--- a/lib/MrMurano/commands/domain.rb
+++ b/lib/MrMurano/commands/domain.rb
@@ -47,6 +47,7 @@ Print the domain for this solution.
           dobj = {}
           dobj[:type] = sol.type.to_s.capitalize
           dobj[:name] = sol.name || ''
+          dobj[:api_id] = sol.api_id || ''
           dobj[:sid] = sol.sid || ''
           dobj[:domain] = ''
           if sol.domain

--- a/lib/MrMurano/commands/init.rb
+++ b/lib/MrMurano/commands/init.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -181,12 +181,12 @@ command :init do |c|
       verbose: true,
     }
     # Get/Create Application ID
-    sol_opts[:match_sid] = options.application_id
+    sol_opts[:match_api_id] = options.application_id
     sol_opts[:match_name] = options.application_name
     sol_opts[:match_fuzzy] = options.application
     appl = solution_find_or_create(biz: biz, type: :application, **sol_opts)
     # Get/Create Product ID
-    sol_opts[:match_sid] = options.product_id
+    sol_opts[:match_api_id] = options.product_id
     sol_opts[:match_name] = options.product_name
     sol_opts[:match_fuzzy] = options.product
     prod = solution_find_or_create(biz: biz, type: :product, **sol_opts)

--- a/lib/MrMurano/commands/link.rb
+++ b/lib/MrMurano/commands/link.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -48,20 +48,20 @@ List the solutions that are linked.
     biz = MrMurano::Business.new
     products = biz.products
     MrMurano::Verbose.whirly_stop
-    pids = products.map(&:apiId)
+    pids = products.map(&:api_id)
 
     sol_opts = { biz: biz, type: :application }
-    sol_opts[:match_sid] = $cfg['application.id'] unless options.all
+    sol_opts[:match_api_id] = $cfg['application.id'] unless options.all
     appl = solution_find_or_create(**sol_opts)
 
     if !appl.nil?
       MrMurano::Verbose.whirly_msg('Fetching application services...')
-      sercfg = MrMurano::ServiceConfig.new(appl.sid)
+      sercfg = MrMurano::ServiceConfig.new(appl.api_id)
       #scfgs = sercfg.list('?select=service,id,solution_id,script_key,alias')
       scfgs = sercfg.list
       MrMurano::Verbose.whirly_stop
     else
-      sercfg = MrMurano::ServiceConfig.new(MrMurano::SolutionId::INVALID_SID)
+      sercfg = MrMurano::ServiceConfig.new(MrMurano::SolutionId::INVALID_API_ID)
       scfgs = []
     end
 
@@ -150,7 +150,7 @@ def link_solutions(sol_a, sol_b, options)
   warn_on_conflict = options[:warn_on_conflict] || false
   verbose = options[:verbose] || false
 
-  if sol_a.nil? || sol_a.sid.to_s.empty? || sol_b.nil? || sol_b.sid.to_s.empty?
+  if sol_a.nil? || sol_a.api_id.to_s.empty? || sol_b.nil? || sol_b.api_id.to_s.empty?
     msg = 'Missing Solution(s) (Applications or Products): Nothing to link'
     if warn_on_conflict
       sercfg.warning msg
@@ -172,9 +172,9 @@ def link_solutions(sol_a, sol_b, options)
 
   # Get services for solution to which being linked (application),
   # and look for linkee (product) service.
-  sercfg = MrMurano::ServiceConfig.new(sol_a.sid)
+  sercfg = MrMurano::ServiceConfig.new(sol_a.api_id)
   MrMurano::Verbose.whirly_msg 'Fetching services...'
-  scfgs = sercfg.search(sol_b.sid)
+  scfgs = sercfg.search(sol_b.api_id)
   svc_cfg_exists = scfgs.any?
   MrMurano::Verbose.whirly_stop
 
@@ -182,7 +182,7 @@ def link_solutions(sol_a, sol_b, options)
   unless svc_cfg_exists
     MrMurano::Verbose.whirly_msg 'Linking solutions...'
     # Call Murano.
-    _ret = sercfg.create(sol_b.sid, sol_b.name) do |request, http|
+    _ret = sercfg.create(sol_b.api_id, sol_b.name) do |request, http|
       response = http.request(request)
       MrMurano::Verbose.whirly_stop
       if response.is_a?(Net::HTTPSuccess)
@@ -208,8 +208,8 @@ def link_solutions(sol_a, sol_b, options)
 
   # Get event handlers for application, and look for product event handler.
   MrMurano::Verbose.whirly_msg 'Fetching handlers...'
-  evthlr = MrMurano::EventHandlerSolnApp.new(sol_a.sid)
-  hdlrs = evthlr.search(sol_b.sid)
+  evthlr = MrMurano::EventHandlerSolnApp.new(sol_a.api_id)
+  hdlrs = evthlr.search(sol_b.api_id)
   evt_hlr_exists = hdlrs.any?
   MrMurano::Verbose.whirly_stop
 
@@ -218,7 +218,7 @@ def link_solutions(sol_a, sol_b, options)
   unless evt_hlr_exists
     MrMurano::Verbose.whirly_msg 'Setting default event handler...'
     # Call Murano.
-    evthlr.default_event_script(sol_b.sid) do |request, http|
+    evthlr.default_event_script(sol_b.api_id) do |request, http|
       response = http.request(request)
       MrMurano::Verbose.whirly_stop
       if response.is_a?(Net::HTTPSuccess)
@@ -244,10 +244,10 @@ def link_solutions(sol_a, sol_b, options)
 end
 
 def unlink_solutions(sol_a, sol_b)
-  sercfg = MrMurano::ServiceConfig.new(sol_a.sid)
+  sercfg = MrMurano::ServiceConfig.new(sol_a.api_id)
   MrMurano::Verbose.whirly_msg 'Fetching services...'
   #scfgs = sercfg.list('?select=service,id,solution_id,script_key,alias')
-  scfgs = sercfg.search(sol_b.sid)
+  scfgs = sercfg.search(sol_b.api_id)
   MrMurano::Verbose.whirly_stop
 
   if scfgs.length > 1
@@ -272,8 +272,8 @@ def unlink_solutions(sol_a, sol_b)
   end
 
   MrMurano::Verbose.whirly_msg 'Fetching handlers...'
-  evthlr = MrMurano::EventHandlerSolnApp.new(sol_a.sid)
-  hdlrs = evthlr.search(sol_b.sid)
+  evthlr = MrMurano::EventHandlerSolnApp.new(sol_a.api_id)
+  hdlrs = evthlr.search(sol_b.api_id)
   #evt_hlr_exists = hdlrs.any?
   MrMurano::Verbose.whirly_stop
 

--- a/lib/MrMurano/commands/postgresql.rb
+++ b/lib/MrMurano/commands/postgresql.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -10,7 +10,7 @@ require 'MrMurano/Solution-ServiceConfig'
 
 module MrMurano
   class Postgresql < ServiceConfig
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       # FIXME/2017-07-03: What soln types have PSQLs?
       @solntype = 'application.id'
       super

--- a/lib/MrMurano/commands/show.rb
+++ b/lib/MrMurano/commands/show.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -39,7 +39,10 @@ Show readable information about the current configuration.
     unless selected_application_id.to_s.empty?
       MrMurano::Verbose.whirly_start('Fetching Applications...')
       biz.applications.each do |sol|
-        selected_application = sol if sol.apiId == selected_application_id
+        next unless sol.api_id == selected_application_id
+        #next unless [sol.api_id, sol.sid].include?(selected_application_id)
+        selected_application = sol
+        break
       end
       MrMurano::Verbose.whirly_stop
     end
@@ -49,7 +52,10 @@ Show readable information about the current configuration.
     unless selected_product_id.to_s.empty?
       MrMurano::Verbose.whirly_start('Fetching Products...')
       biz.products.each do |sol|
-        selected_product = sol if sol.apiId == selected_product_id
+        next unless sol.api_id == selected_product_id
+        #next unless [sol.api_id, sol.sid].include?(selected_product_id)
+        selected_product = sol
+        break
       end
       MrMurano::Verbose.whirly_stop
     end
@@ -71,11 +77,11 @@ Show readable information about the current configuration.
 
     id_not_in_biz = false
 
-    # E.g., {:bizid=>"ABC", :type=>"application", :apiId=>"XXX", :sid=>"XXX",
+    # E.g., {:bizid=>"ABC", :type=>"application", :api_id=>"XXX", :sid=>"XXX",
     #        :name=>"ABC", :domain=>"ABC.apps.exosite.io" }
     if selected_application
       sol_info = %(application: https://#{selected_application.domain})
-      sol_info += %( <#{selected_application.sid}>) if options.ids
+      sol_info += %( <#{selected_application.api_id}>) if options.ids
       puts sol_info
     elsif selected_application_id
       #puts 'selected application not in business'
@@ -88,11 +94,11 @@ Show readable information about the current configuration.
       puts 'application ID not found in config'
     end
 
-    # E.g., {:bizid=>"ABC", :type=>"product", :apiId=>"XXX", :sid=>"XXX",
+    # E.g., {:bizid=>"ABC", :type=>"product", :api_id=>"XXX", :sid=>"XXX",
     #        :name=>"ABC", :domain=>"ABC.m2.exosite.io" }
     if selected_product
       sol_info = %(product: #{selected_product.name})
-      sol_info += %( <#{selected_product.sid}>) if options.ids
+      sol_info += %( <#{selected_product.api_id}>) if options.ids
       puts sol_info
     elsif selected_product_id
       #puts 'selected product not in business'

--- a/lib/MrMurano/commands/timeseries.rb
+++ b/lib/MrMurano/commands/timeseries.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -11,7 +11,7 @@ require 'MrMurano/Solution-ServiceConfig'
 
 module MrMurano
   class Timeseries < ServiceConfig
-    def initialize(sid=nil)
+    def initialize(api_id=nil)
       # FIXME/2017-07-03: What soln types have timeseries?
       @solntype = 'application.id'
       super

--- a/lib/MrMurano/commands/tsdb.rb
+++ b/lib/MrMurano/commands/tsdb.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -13,7 +13,7 @@ require 'MrMurano/SubCmdGroupContext'
 module MrMurano
   module ServiceConfigs
     class Tsdb < ServiceConfig
-      def initialize(sid=nil)
+      def initialize(api_id=nil)
         # FIXME/2017-07-03: What soln types have TSDBs?
         @solntype = 'application.id'
         super

--- a/spec/Business_spec.rb
+++ b/spec/Business_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.02 /coding: utf-8
+# Last Modified: 2017.09.11 /coding: utf-8
 
 # Copyright © 2016-2017 Exosite LLC.
 # License: MIT. See LICENSE.txt.
@@ -37,6 +37,7 @@ RSpec.describe MrMurano::Business do
        pid: "ABC",
        modelId: "cde",
        label: "fts",
+       api_id: "XYZ",
        sid: "XYZ",
        name: "XYZ",},
       {bizid: "XYZxyz",
@@ -44,6 +45,7 @@ RSpec.describe MrMurano::Business do
        pid: "fgh",
        modelId: "ijk",
        label: "lua-test",
+       api_id: "XYZ",
        sid: "XYZ",
        name: "XYZ",},
     ]
@@ -106,14 +108,14 @@ RSpec.describe MrMurano::Business do
       {bizid: "XYZxyz",
        type: "application",
        domain: "XYZxyz.apps.exosite.io",
-       apiId: "ACBabc",
+       api_id: "ACBabc",
        sid: "ACBabc",
        name: "ijk",
       },
       {bizid: "XYZxyz",
        type: "application",
        domain: "XYZxyz.apps.exosite.io",
-       apiId: "DEFdef",
+       api_id: "DEFdef",
        sid: "DEFdef",
        name: "lmn",
       },
@@ -183,7 +185,7 @@ RSpec.describe MrMurano::Business do
       {bizid: "XYZxyz",
        type: "product",
        domain: "ABCabc.m2.exosite.io",
-       apiId: "ABCabc",
+       api_id: "ABCabc",
        sid: "ABCabc",
        name: "XXX",
       },
@@ -192,7 +194,7 @@ RSpec.describe MrMurano::Business do
       {bizid: "XYZxyz",
        type: "application",
        domain: "XYZxyz.apps.exosite.io",
-       apiId: "DEFdef",
+       api_id: "DEFdef",
        sid: "DEFdef",
        name: "XXX",
       },
@@ -222,7 +224,7 @@ RSpec.describe MrMurano::Business do
 
     sol = @biz.new_solution!("one", :product)
     expect(sol.valid?).to be true
-    expect(sol.sid).to eq("abc123def456ghi78")
+    expect(sol.api_id).to eq("abc123def456ghi78")
   end
 
 #  if false

--- a/spec/Solution-ServiceConfig_spec.rb
+++ b/spec/Solution-ServiceConfig_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MrMurano::ServiceConfig do
     $cfg['product.id'] = 'XYZ'
     $cfg['application.id'] = 'XYZ'
 
-    # ServiceConfig needs an sid, else one could instantiate
+    # ServiceConfig needs an api_id, else one could instantiate
     # ServiceConfigApplication or ServiceConfigProduct.
     @srv = MrMurano::ServiceConfig.new('XYZ')
     allow(@srv).to receive(:token).and_return("TTTTTTTTTT")

--- a/spec/SyncUpDown_spec.rb
+++ b/spec/SyncUpDown_spec.rb
@@ -12,20 +12,20 @@ class TSUD
 
   def initialize
     # 2017-07-03: See MrMurano::SolutionBase.state for the list of attrs.
-    @sid = 'XYZ'
-    @valid_sid = true
+    @api_id = 'XYZ'
+    @valid_api_id = true
     @uriparts = []
     @solntype = 'application.id'
     @itemkey = :name
     @project_section = :routes
   end
 
-  def sid
-    @sid
+  def api_id
+    @api_id
   end
 
-  def sid?
-    @valid_sid
+  def api_id?
+    @valid_api_id
   end
 
   def fetch(id)


### PR DESCRIPTION
### Fix apiId vs sid confusion. (Issue: MRMUR-159)
    
- Code was using `:sid` for everything and ignoring `:apiId`, but for old businesses (Murano 1.0 businesses that have been "migrated"), `sid` != `apiId`.
  - Use `sid` for `business/<bid>/solution/<sid>`
  - Use `apiId` for `solution/<apiId>`
