### PR TITLE
Fix Windows support. (Issue: MRMUR-160, MRMUR-161)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.30 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -22,11 +22,15 @@ gem 'json-schema', '~> 2.7.0'
 gem 'mime-types', '~> 3.1'
 gem 'mime-types-data', '~> 3.2016.0521'
 #gem 'orderedhash', '~> 0.0.6'
+gem 'os', '~> 1.0.0'
 gem 'paint', '~> 2.0.0'
 # 2017-08-04: public_suffix 3.0.0 is for Ruby >= 2.1.
 #   It's included by json, so make sure it's the old one.
 gem 'public_suffix', '~> 2.0.5'
 gem 'rainbow', '~> 2.2.2'
+# LATER/2017-09-12: See MRMUR-160 and MRMUR-161:
+#   Windows build fails unless `rake` is packaged.
+gem 'rake', '~> 12.1.0'
 gem 'terminal-table', '~> 1.8.0'
 gem 'vine', '~> 0.4'
 gem 'whirly', '~> 0.2.4'
@@ -35,7 +39,7 @@ group :test do
   #gem 'bundler', '~> 1.7.6'
   gem 'byebug', '~> 9.0.6'
   gem 'coderay', require: false
-  gem 'rake', '~> 10.1.1'
+  #gem 'rake', '~> 10.1.1'
   gem 'rspec', '~> 3.5'
   gem 'rubocop', '~> 0.49.1'
   gem 'simplecov', require: false
@@ -45,6 +49,8 @@ group :test do
 end
 
 group :windows do
-  gem 'ocra', '~> 1.3.8'
+  # FIXME/2017-09-12: Pin to 1.3.8 until x86 issue is resolved:
+  #   https://github.com/larsch/ocra/issues/124
+  gem 'ocra', '1.3.8'
 end
 

--- a/MuranoCLI.gemspec
+++ b/MuranoCLI.gemspec
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.30 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -63,6 +63,7 @@ explicitly specifying the version. For instance,
   s.add_runtime_dependency('mime-types', '~> 3.1')
   s.add_runtime_dependency('mime-types-data', '~> 3.2016.0521')
   #s.add_runtime_dependency('orderedhash', '~> 0.0.6')
+  s.add_runtime_dependency('os', '~> 1.0.0')
   s.add_runtime_dependency('paint', '~> 2.0.0')
   # 2017-08-04: public_suffix 3.0.0 is for Ruby >= 2.1.
   #   It's included by json, so make sure it's the old one.
@@ -71,11 +72,15 @@ explicitly specifying the version. For instance,
   s.add_runtime_dependency('terminal-table', '~> 1.8.0')
   s.add_runtime_dependency('vine', '~> 0.4')
   s.add_runtime_dependency('whirly', '~> 0.2.4')
+  # LATER/2017-09-12: See MRMUR-160 and MRMUR-161:
+  #   Windows build fails unless `rake` is packaged.
+  s.add_runtime_dependency('rake', '~> 12.1.0')
 
+  # `bundle install --with=test`
   s.add_development_dependency('bundler', '~> 1.7.6')
   s.add_development_dependency('byebug', '~> 9.0.6')
   #s.add_development_dependency('coderay', '~> ???')
-  s.add_development_dependency('rake', '~> 10.1.1')
+  #s.add_development_dependency('rake', '~> 12.1.0')
   s.add_development_dependency('rspec', '~> 3.5')
   s.add_development_dependency('rubocop', '~> 0.49.1')
   s.add_development_dependency('simplecov')
@@ -83,7 +88,9 @@ explicitly specifying the version. For instance,
   # maybe? s.add_development_dependency('vcr', '~> ???')
   s.add_development_dependency('yard')
 
-  # Windows:
-  s.add_development_dependency('ocra', '~> 1.3.8')
+  # `bundle install --with=windows`
+  # FIXME/2017-09-12: Pin to 1.3.8 until x86 issue is resolved:
+  #   https://github.com/larsch/ocra/issues/124
+  s.add_development_dependency('ocra', '1.3.8')
 end
 

--- a/lib/MrMurano.rb
+++ b/lib/MrMurano.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.29 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -49,4 +49,8 @@ require 'MrMurano/SyncUpDown'
 require 'MrMurano/SubCmdGroupContext'
 require 'MrMurano/ReCommander'
 require 'MrMurano/commands'
+
+# LATER/2017-09-12: See MRMUR-160 and MRMUR-161:
+#   Windows build fails unless `rake` is packaged.
+require 'rake'
 

--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.11 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -10,6 +10,7 @@
 
 require 'inflecto'
 require 'open3'
+require 'os'
 require 'pathname'
 #require 'shellwords'
 require 'tempfile'
@@ -352,8 +353,10 @@ module MrMurano
         # This happens on Windows...
         require 'rbconfig'
         # Check the platform, e.g., "linux-gnu", or other.
-        is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-        unless is_windows
+        #is_windows = (
+        #  RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+        #)
+        unless OS.windows?
           msg = 'Unexpected: touch failed on non-Windows machine'
           $stderr.puts("#{msg} / host_os: #{RbConfig::CONFIG['host_os']} / err: #{err}")
         end

--- a/lib/MrMurano/progress.rb
+++ b/lib/MrMurano/progress.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -7,6 +7,7 @@
 
 require 'highline'
 require 'inflecto'
+require 'os'
 require 'singleton'
 require 'whirly'
 
@@ -60,12 +61,20 @@ module MrMurano
     end
 
     def whirly_show
+      if $cfg['tool.ascii'] || OS.windows?
+        spinner = EXO_QUADRANTS_7
+        ansi_escape_mode = 'line'
+      else
+        spinner = EXO_QUADRANTS
+        ansi_escape_mode = 'restore'
+      end
       Whirly.start(
-        spinner: $cfg['tool.ascii'] && EXO_QUADRANTS_7 || EXO_QUADRANTS,
+        spinner: spinner,
         status: @whirly_msg,
         append_newline: false,
         #remove_after_stop: false,
         #stream: $stderr,
+        ansi_escape_mode: ansi_escape_mode,
       )
       @whirly_time = Time.now
       # The whitespace we add ends up getting picked up if you copy

--- a/lib/MrMurano/verbosing.rb
+++ b/lib/MrMurano/verbosing.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.28 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -9,6 +9,7 @@ require 'csv'
 require 'highline'
 require 'inflecto'
 require 'json'
+require 'os'
 require 'paint'
 require 'pp'
 require 'terminal-table'
@@ -173,7 +174,7 @@ module MrMurano
     end
 
     def self.fancy_ticks(obj)
-      if $cfg.nil? || $cfg['tool.ascii']
+      if $cfg.nil? || $cfg['tool.ascii'] || OS.windows?
         "'#{obj}'"
       else
         "‘#{obj}’"

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.31 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -26,7 +26,7 @@ module MrMurano
   #     '3.0.0-beta.2' is changed to '3.0.0.pre.beta.2'
   #   which breaks our build (which expects the version to match herein).
   #   So stick to using the '.pre.X' syntax, which ruby/gems knows.
-  VERSION = '3.0.2'
+  VERSION = '3.0.3'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end

--- a/spec/cmd_common.rb
+++ b/spec/cmd_common.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.31 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -8,6 +8,7 @@
 require 'highline'
 # Set HighLine's $terminal global.
 require 'highline/import'
+require 'os'
 require 'pathname'
 require 'shellwords'
 require 'timeout'
@@ -107,8 +108,10 @@ RSpec.shared_context 'CI_CMD' do
       # This happens on Windows...
       require 'rbconfig'
       # Check the platform, e.g., "linux-gnu", or other.
-      is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-      unless is_windows
+      #is_windows = (
+      #  RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+      #)
+      unless OS.windows?
         $stderr.puts(
           'Unexpected: ln_s failed on non-Windows machine / ' \
           "host_os: #{RbConfig::CONFIG['host_os']} / err: #{err}"

--- a/spec/cmd_status_spec.rb
+++ b/spec/cmd_status_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.17 /coding: utf-8
+# Last Modified: 2017.09.12 /coding: utf-8
 # frozen_string_literal: probably not yet
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -8,6 +8,7 @@
 require 'fileutils'
 require 'json'
 require 'open3'
+require 'os'
 require 'pathname'
 require 'rbconfig'
 
@@ -173,8 +174,10 @@ RSpec.describe 'murano status', :cmd, :needs_password do
       # Check the platform, e.g., "linux-gnu", or other.
       # 2017-07-14 08:51: Is there a race condition here? [lb] saw
       # differences earlier, but then not after adding this...
-      #is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-      #if is_windows
+      #is_windows = (
+      #  RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+      #)
+      #if OS.windows?
       #  expect(olines[14]).to eq("Items that differ:\n")
       #  expect(olines[15..16]).to contain_exactly(
       #    a_string_matching(/ M \w  .*services\/timer_timer\.lua/),
@@ -238,8 +241,10 @@ RSpec.describe 'murano status', :cmd, :needs_password do
 
       # NOTE: On Windows, touch doesn't work, so items differ.
       # Check the platform, e.g., "linux-gnu", or other.
-      is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-      if is_windows
+      #is_windows = (
+      #  RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+      #)
+      if OS.windows?
         expect(olines[14]).to eq("Items that differ:\n")
         expect(olines[15..16]).to include(
           a_string_matching(/ M \w  .*services\/timer_timer\.lua/),


### PR DESCRIPTION
- Pin `ocra` gem at 1.3.8.
  - The 1.3.9 release has a bug that always creates 64-bit executables, even on x86.
- Add `rake` to gem dependencies, to fix require complaint without...
- Replace checking `RbConfig::CONFIG['host_os']` and use more complete `os` gem, to check if on Windows or not.
- Do not choose ANSI spinner on Windows; use ASCII-7.
  - Also use alternative (experimental) ANSI escapes.