### PR TITLE
Support Two-factor Authentication

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -7,10 +7,12 @@ report/
 .rspec_examples.txt
 Gemfile.lock
 .bundle/
+tags
 
 # 2017-05-12: Testing!
 *.out
 .rake_build.out
+curldebug.out
 
 rspec-*.html
 *.rspec.html

--- a/.trustme.sh
+++ b/.trustme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Last Modified: 2017.08.16
+# Last Modified: 2017.09.20
 # vim:tw=0:ts=2:sw=2:et:norl:spell
 
 # WHAT: A Continuous Integration (CI) script for kicking the build
@@ -170,6 +170,19 @@ function rspec_it() {
 # especially if your tests use the same
 # business as you do when developing.
 #rspec_it
+
+function ctags_it() {
+  annoucement "CTAGS IT"
+  ctags -R \
+    --exclude=coverage \
+    --exclude=docs \
+    --exclude=pkg \
+    --exclude=report \
+    --exclude=spec \
+    --verbose=yes
+  /bin/ls -la tags >> ${OUT_FILE}
+}
+ctags_it
 
 time_n=$(date +%s.%N)
 time_elapsed=$(echo "$time_n - $time_0" | bc -l)

--- a/.trustme.vim
+++ b/.trustme.vim
@@ -23,6 +23,8 @@
 "  autocmd BufWritePost <buffer> silent !./.trustme.sh &
 "augroup END
 
+autocmd BufRead *.rb set tags=/exo/clients/exosite/exosite-murcli/tags
+
 "echomsg 'Calling trustme.sh'
 silent !./.trustme.sh &
 

--- a/lib/MrMurano/Account.rb
+++ b/lib/MrMurano/Account.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.22 /coding: utf-8
+# Last Modified: 2017.09.21 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -55,6 +55,7 @@ Or set your password with `murano password set <username>`.
 
     def login_info
       warned_once = false
+
       if user.empty?
         prologue = 'No Murano user account found.'
         unless $cfg.prompt_if_logged_off
@@ -70,9 +71,8 @@ Or set your password with `murano password set <username>`.
         $project.refresh_user_name
         MrMurano::Verbose.whirly_unpause
       end
-      pwd_path = $cfg.file_at('passwords', :user)
-      pwd_file = MrMurano::Passwords.new(pwd_path)
-      pwd_file.load
+
+      pwd_file = pwd_file_load
       user_pass = pwd_file.get(host, user)
       if user_pass.nil?
         prologue = "No Murano password found for #{user}."
@@ -85,19 +85,42 @@ Or set your password with `murano password set <username>`.
         error(%(#{prologue} #{LOGIN_NOTICE}).strip) unless warned_once
         user_pass = ask('Password: ') { |q| q.echo = '*' }
         pwd_file.set(host, user, user_pass)
+        pwd_file.set(host, user + '/twofactor', nil)
         pwd_file.save
         MrMurano::Verbose.whirly_unpause
+      else
+        @twofactor_token = token_twofactor_lookup(pwd_file)
       end
-      creds = {
+
+      {
         email: user,
         password: user_pass,
       }
-      creds
+    end
+
+    def pwd_file_load
+      pwd_path = $cfg.file_at('passwords', :user)
+      pwd_file = MrMurano::Passwords.new(pwd_path)
+      pwd_file.load
+      pwd_file
+    end
+
+    def token_twofactor_lookup(pwd_file)
+      twoftoken = pwd_file.lookup(host, user + '/twofactor')
+      if twoftoken.to_s.empty?
+        nil
+      elsif twoftoken !~ /^[a-fA-F0-9]+$/
+        warning "Malformed twofactor token: #{twoftoken}"
+        nil
+      else
+        twoftoken
+      end
     end
 
     # ---------------------------------------------------------------------
 
     def token
+      return '' if defined?(@logging_on) && @logging_on
       token_fetch if @token.to_s.empty?
       @token
     end
@@ -107,32 +130,140 @@ Or set your password with `murano password set <username>`.
     end
 
     def token_fetch
-      # Cannot have token call token, so cannot use Http::workit.
-      uri = endpoint('token/')
-      request = Net::HTTP::Post.new(uri)
-      request['User-Agent'] = "MrMurano/#{MrMurano::VERSION}"
-      request.content_type = 'application/json'
-      curldebug(request)
-      #request.basic_auth(username(), password())
-      request.body = JSON.generate(login_info)
+      @logging_on = true
+      creds = login_info
+      @token = nil
+
+      # If 2fa token found, verify it works.
+      unless @twofactor_token.nil?
+        get('token/' + @twofactor_token) do |request, http|
+          http.request(request) do |response|
+            if response.is_a?(Net::HTTPSuccess)
+              # response.body is, e.g., "{\"email\":\"xxx@yyy.zzz\",\"ttl\":172800}"
+              @token = @twofactor_token
+            end
+          end
+        end
+        unless @token.nil?
+          @logging_on = false
+          return
+        end
+        @twofactor_token = nil
+      end
 
       MrMurano::Verbose.whirly_start('Logging in...')
-      response = http.request(request)
+      post('token/', creds) do |request, http|
+        http.request(request) do |response|
+
+          reply = JSON.parse(response.body, json_opts)
+          if response.is_a?(Net::HTTPSuccess)
+            @token = reply[:token]
+          elsif response.is_a?(Net::HTTPConflict) && reply[:message] == 'twofactor'
+            MrMurano::Verbose.whirly_interject do
+              # Prompt user for emailed code.
+              token_twofactor_fetch(creds)
+            end
+          else
+            showHttpError(request, response)
+            error 'Check to see if username and password are correct.'
+            unless ENV['MURANO_PASSWORD'].to_s.empty?
+              pwd_path = $cfg.file_at('passwords', :user)
+              warning "NOTE: MURANO_PASSWORD specifies the password; it was not read from #{pwd_path}"
+            end
+          end
+        end
+      end
+      MrMurano::Verbose.whirly_stop
+      @logging_on = false
+    end
+
+    def token_twofactor_fetch(creds)
+      error 'Two-factor Authentication'
+      warning 'A verification code has been sent to your email.'
+      code = ask('Please enter the code here to continue: ').strip
+      unless code =~ /^[a-fA-F0-9]+$/
+        error 'Expected token to contain only numbers and hexadecimal letters.'
+        exit 1
+      end
+      MrMurano::Verbose.whirly_start('Verifying code...')
+
+      path = 'key/' + code
+
+      response = get(path)
+      # Response is, e.g., {
+      #   purpose: "twofactor",
+      #   status: "exists",
+      #   email: "xxx@yyy.zzz",
+      #   bizid: null,
+      #   businessName: null, }
+      return if response.nil?
+
+      response = post(path, password: creds[:password])
+      # Response is, e.g., { "token": "..." }
+      return if response.nil?
+
+      @twofactor_token = response[:token]
+      pwd_file = pwd_file_load
+      pwd_file.set(host, user + '/twofactor', @twofactor_token)
+      pwd_file.save
+      @token = @twofactor_token
       MrMurano::Verbose.whirly_stop
 
-      case response
-      when Net::HTTPSuccess
-        token = JSON.parse(response.body, json_opts)
-        @token = token[:token]
-      else
-        showHttpError(request, response)
-        error 'Check to see if username and password are correct.'
-        unless ENV['MURANO_PASSWORD'].to_s.empty?
-          pwd_path = $cfg.file_at('passwords', :user)
-          warning "NOTE: MURANO_PASSWORD specifies the password; it was not read from #{pwd_path}"
-        end
-        @token = nil
+      warning 'Please run `murano logout --token` to clear your two-factor token when finished.'
+    end
+
+    def logout(token_delete_only)
+      @logging_on = true
+
+      pwd_file = pwd_file_load
+      twoftoken = token_twofactor_lookup(pwd_file)
+
+      # First, delete/invalidate the remote token.
+      unless twoftoken.to_s.empty?
+        @suppress_error = true
+        resp = delete('token/' + twoftoken)
+        # resp is nil if token not recognized, else it's {}. We don't really
+        # care, since we're going to forget our copy of the token, anyway.
+        @suppress_error = false
       end
+
+      net_host = verify_set('net.host')
+      user_name = verify_set('user.name')
+      if net_host && user_name
+        pwd_file = MrMurano::Passwords.new
+        pwd_file.load
+        pwd_file.remove(net_host, user_name) unless token_delete_only
+        pwd_file.remove(net_host, user_name + '/twofactor')
+        pwd_file.save
+      end
+
+      clear_from_config(net_host, user_name) unless token_delete_only
+
+      @logging_on = false
+    end
+
+    def clear_from_config(net_host, user_name)
+      user_net_host = $cfg.get('net.host', :user)
+      user_net_host = $cfg.get('net.host', :defaults) if user_net_host.nil?
+      user_user_name = $cfg.get('user.name', :user)
+      if (user_net_host == net_host) && (user_user_name == user_name)
+        # Only clear user name from the user config if the net.host
+        # or user.name did not come from a different config, like the
+        # --project config.
+        $cfg.set('user.name', nil, :user)
+        $cfg.set('business.id', nil, :user)
+        $cfg.set('business.name', nil, :user)
+      end
+    end
+
+    def verify_set(cfg_key)
+      cfg_val = $cfg.get(cfg_key)
+      if cfg_val.to_s.empty?
+        cfg_val = nil
+        cfg_key_q = MrMurano::Verbose.fancy_ticks(cfg_key)
+        MrMurano::Verbose.warning("No config key #{cfg_key_q}: no password to delete")
+      end
+      cfg_val
     end
 
     # ---------------------------------------------------------------------

--- a/lib/MrMurano/Business.rb
+++ b/lib/MrMurano/Business.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.11 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -109,12 +109,7 @@ module MrMurano
 
     def self.missing_business_id_msg
       %(
-Missing Business ID.
-Call `#{MrMurano::EXE_NAME} business list` to get a list of business IDs.
-Set the ID temporarily using --config business.id=<ID>
-or add to the project config using \`#{MrMurano::EXE_NAME} config business.id <ID>\`
-or add to the user config using \`#{MrMurano::EXE_NAME} config business.id <ID> --user\`
-or set it interactively using \`#{MrMurano::EXE_NAME} init\`
+business ID not specified. For hints: #{MrMurano::EXE_NAME} business --help
       ).strip
     end
 

--- a/lib/MrMurano/Config.rb
+++ b/lib/MrMurano/Config.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.31 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -301,7 +301,7 @@ module MrMurano
         if the_cmd.name != 'help' && !the_cmd.project_not_required && !@project_exists
           error %(The "#{the_cmd.name}" command only works in a Murano project.)
           say INVALID_PROJECT_HINT
-          # Note that commnander-rb uses an at_exit hook, which we hack around.
+          # Note that commander-rb uses an at_exit hook, which we hack around.
           @runner.command_exit = 1
           false
         end

--- a/lib/MrMurano/Passwords.rb
+++ b/lib/MrMurano/Passwords.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -69,6 +69,10 @@ module MrMurano
         ).strip
         return ENV['MR_PASSWORD']
       end
+      lookup(host, user)
+    end
+
+    def lookup(host, user)
       return nil unless @data.is_a?(Hash)
       return nil unless @data.key?(host)
       return nil unless @data[host].is_a?(Hash)

--- a/lib/MrMurano/commands/business.rb
+++ b/lib/MrMurano/commands/business.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.11 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -20,6 +20,16 @@ command :business do |c|
   c.summary = %(About business)
   c.description = %(
 Commands for working with businesses.
+
+If you need to set the business ID, try some of the following:
+
+- Get a list of Business IDs:       #{MrMurano::EXE_NAME} business list
+
+- Specify the ID explictly:         #{MrMurano::EXE_NAME} <cmd> --config business.id=<ID>
+  Add the ID to a project config:   #{MrMurano::EXE_NAME} config business.id <ID>
+  Add the ID to the user config:    #{MrMurano::EXE_NAME} config business.id <ID> --user
+  Setup a project interactively:    #{MrMurano::EXE_NAME} init
+
   ).strip
   c.project_not_required = true
   c.subcmdgrouphelp = true

--- a/lib/MrMurano/commands/exchange.rb
+++ b/lib/MrMurano/commands/exchange.rb
@@ -62,6 +62,7 @@ Element status:
     cmd_defaults_id_and_name(options)
 
     xchg = MrMurano::Exchange.new
+    xchg.must_business_id!
 
     elems, available, purchased = find_elements(xchg, options, args[0])
     if options.added.nil?
@@ -233,6 +234,7 @@ Add an Exchange Element to your Business.
     cmd_defaults_id_and_name(options)
 
     xchg = MrMurano::Exchange.new
+    xchg.must_business_id!
 
     # If the user specifies filter_id, we could try to fetch that Element
     # directly (e.g., by calling exchange/<bizId>/element/<elemId>),

--- a/lib/MrMurano/commands/exchange.rb
+++ b/lib/MrMurano/commands/exchange.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.31 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -169,7 +169,7 @@ def cmd_exchange_header_and_elems(elems, options)
       # Calculate the width of each column except the last (:description).
       headers[0..-2].each do |key|
         elem_with_max = elems.max { |a, b| a.send(key).length <=> b.send(key).length }
-        width_taken += elem_with_max.send(key).length
+        width_taken += elem_with_max.send(key).length unless elem_with_max.nil?
         width_taken += ' | '.length
       end
       width_taken += ' | '.length

--- a/lib/MrMurano/commands/login.rb
+++ b/lib/MrMurano/commands/login.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.09.21 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -42,43 +42,16 @@ it will remove that user's password from the password file.
 Essentially, this command is the same as:
 
   murano password delete <username>
+  murano password delete <username>/twofactor
   murano config --unset --user user.name
   ).strip
   c.project_not_required = true
 
-  c.action do |args, _options|
+  c.option '--token', 'Remove just the two-factor token'
+
+  c.action do |args, options|
     c.verify_arg_count!(args)
-
-    net_host = verify_set('net.host')
-    user_name = verify_set('user.name')
-    if net_host && user_name
-      psd = MrMurano::Passwords.new
-      psd.load
-      psd.remove(net_host, user_name)
-      psd.save
-    end
-
-    user_net_host = $cfg.get('net.host', :user)
-    user_net_host = $cfg.get('net.host', :defaults) if user_net_host.nil?
-    user_user_name = $cfg.get('user.name', :user)
-    if (user_net_host == net_host) && (user_user_name == user_name)
-      # Only clear user name from the user config if the net.host
-      # or user.name did not come from a different config, like the
-      # --project config.
-      $cfg.set('user.name', nil, :user)
-      $cfg.set('business.id', nil, :user)
-      $cfg.set('business.name', nil, :user)
-    end
-  end
-
-  def verify_set(cfg_key)
-    cfg_val = $cfg.get(cfg_key)
-    if cfg_val.to_s.empty?
-      cfg_val = nil
-      cfg_key_q = MrMurano::Verbose.fancy_ticks(cfg_key)
-      MrMurano::Verbose.warning("No config key #{cfg_key_q}: no password to delete")
-    end
-    cfg_val
+    MrMurano::Account.instance.logout(options.token)
   end
 end
 

--- a/lib/MrMurano/commands/usage.rb
+++ b/lib/MrMurano/commands/usage.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.16 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -10,15 +10,16 @@ require 'MrMurano/Solution'
 
 command :usage do |c|
   c.syntax = %(murano usage)
-  c.summary = %(Get usage info for solution(s))
+  c.summary = %(Get usage info for the Application and Product)
   c.description = %(
-Get usage info for solution(s).
+Get usage info for the Application and Product.
   ).strip
+  c.project_not_required = true
 
   # Add flag: --type [application|product|all].
   cmd_add_solntype_pickers(c)
 
-  c.option '--[no-]all', 'Show usage for all Solutions in Business, not just Project'
+  c.option '--[no-]all', 'Show usage for all Solutions in Business'
   c.option(
     '--[no-]header', %(Output solution descriptions (default: true))
   )

--- a/lib/MrMurano/http.rb
+++ b/lib/MrMurano/http.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.24 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -108,7 +108,7 @@ module MrMurano
       # 2017-08-14: MrMurano::Account overrides the token method, and
       # it doesn't exit if no token, and then we end up here.
       ensure_token! token
-      request['Authorization'] = 'token ' + token
+      request['Authorization'] = 'token ' + token unless token.to_s.empty?
       request['User-Agent'] = "MrMurano/#{MrMurano::VERSION}"
       request
     end

--- a/spec/Account_spec.rb
+++ b/spec/Account_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.12 /coding: utf-8
+# Last Modified: 2017.09.21 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -45,6 +45,7 @@ RSpec.describe MrMurano::Account, 'token' do
     it 'Asks for nothing' do
       $cfg['user.name'] = 'bob'
       expect(@pswd).to receive(:get).once.and_return('built')
+      expect(@pswd).to receive(:lookup).once.and_return(nil)
 
       ret = @acc.login_info
       expect(ret).to eq(email: 'bob', password: 'built')
@@ -56,6 +57,7 @@ RSpec.describe MrMurano::Account, 'token' do
       expect(@acc).to receive(:error).once
       expect($cfg).to receive(:set).with('user.name', 'bob', :user).once.and_call_original
       expect(@pswd).to receive(:get).once.and_return('built')
+      expect(@pswd).to receive(:lookup).once.and_return(nil)
 
       ret = @acc.login_info
       expect(ret).to eq(email: 'bob', password: 'built')
@@ -67,6 +69,7 @@ RSpec.describe MrMurano::Account, 'token' do
       expect(@acc).to receive(:error).once
       expect($terminal).to receive(:ask).once.and_return('dog')
       expect(@pswd).to receive(:set).once.with('bizapi.hosted.exosite.io', 'bob', 'dog')
+      expect(@pswd).to receive(:set).once.with('bizapi.hosted.exosite.io', 'bob/twofactor', nil)
       # 2017-07-31: login_info may exit unless the command okays prompting for the password.
       #   (If we don't set this, login_info exits, which we'd want to
       #   catch with

--- a/spec/Content_spec.rb
+++ b/spec/Content_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.13 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -10,6 +10,14 @@ require 'MrMurano/version'
 require 'MrMurano/Content'
 require 'MrMurano/SyncRoot'
 require '_workspace'
+
+# rubocop:disable Style/HashSyntax
+# - 'Use the new Ruby 1.9 hash syntax.'
+#   E.g.,
+#     :'x-amz-meta-name' => 'Solutionfile.json',
+#   because quoted string keys, e.g.,
+#     'x-amz-meta-name': 'Solutionfile.json',
+#   are not supported in Ruby 2.0.
 
 RSpec.describe MrMurano::Content::Base do
   include_context 'WORKSPACE'

--- a/spec/cmd_syncup_spec.rb
+++ b/spec/cmd_syncup_spec.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.12 /coding: utf-8
+# Last Modified: 2017.09.20 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -82,7 +82,7 @@ RSpec.describe 'murano syncup', :cmd, :needs_password do
       # Windows is insane:
       #   "Adding item ........................Administrator.AppData.Local.Temp.2.d20170913-3860-pgji6g.project.modules.table_util\n"
       #expect(outl[5]).to eq("Adding item table_util\n")
-      expect(outl[5]).to start_with("Adding item ")
+      expect(outl[5]).to start_with('Adding item ')
       expect(outl[5]).to end_with("table_util\n")
       #expect(outl[6]).to eq("Updating item c3juj9vnmec000000_event\n")
       # The order isn't always consistent, so just do start_with.


### PR DESCRIPTION
- If 2FA in use, CLI stores the bizapi token in the passwords file.

  - For first call, when token not set, CLI tells user to check email
    and asks for authorization code. It then stores the fetched token
    in the passwords file.

  - On subsequent calls, token is retrieved from passwords file.

  - If CLI didn't store the token, the user would be emailed and
    prompted for every CLI invocation.

  - The user is told to `murano logout --token` when finished,
    which deletes the token from `bizapi` and from `~/.murano/passwords`