### PR TITLE
Release: v3.0.6

### DIFF
--- a/lib/MrMurano/commands/devices.rb
+++ b/lib/MrMurano/commands/devices.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.08.23 /coding: utf-8
+# Last Modified: 2017.10.04 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -239,7 +239,7 @@ Enables Identifiers, creating devices, or digital shadows, in Murano.
 
     unless options.auth.nil?
       options.auth = options.auth.to_sym
-      unless MrMurano::Gateway::Device.DEVICE_AUTH_TYPES.include?(options.auth)
+      unless MrMurano::Gateway::Device::DEVICE_AUTH_TYPES.include?(options.auth)
         MrMurano::Verbose.error("unrecognized --auth: #{options.auth}")
         exit 1
       end

--- a/lib/MrMurano/version.rb
+++ b/lib/MrMurano/version.rb
@@ -1,4 +1,4 @@
-# Last Modified: 2017.09.28 /coding: utf-8
+# Last Modified: 2017.10.06 /coding: utf-8
 # frozen_string_literal: true
 
 # Copyright © 2016-2017 Exosite LLC.
@@ -26,7 +26,7 @@ module MrMurano
   #     '3.0.0-beta.2' is changed to '3.0.0.pre.beta.2'
   #   which breaks our build (which expects the version to match herein).
   #   So stick to using the '.pre.X' syntax, which ruby/gems knows.
-  VERSION = '3.0.5'
+  VERSION = '3.0.6'
   EXE_NAME = File.basename($PROGRAM_NAME)
   SIGN_UP_URL = 'https://exosite.com/signup/'
 end


### PR DESCRIPTION
# Murano CLI v3.0.6

- Fix `tsdb query` command to work when `--sampling_size` not specified. (Issue: MUR-4301)

- Fix `device enable` command. (Issue: MUR-4537)
