### PR TITLE
Be more inclusive: Use include?, not fnmatch, when checking patterns on syncup.

### DIFF
--- a/lib/MrMurano/SyncUpDown.rb
+++ b/lib/MrMurano/SyncUpDown.rb
@@ -894,7 +894,7 @@ module MrMurano
               lpath = tolocalpath(into, item)
               lpath.to_s.include? pattern
             else
-              item[:local_path].fnmatch(pattern)
+              item[:local_path].to_s.include? pattern
             end
           end
         end


### PR DESCRIPTION
I missed a line from last time...

https://jira.exosite.com/browse/MUR-5042